### PR TITLE
✨ [WIP] Add task table to problems page (#232)

### DIFF
--- a/src/lib/components/TaskTable.svelte
+++ b/src/lib/components/TaskTable.svelte
@@ -1,0 +1,85 @@
+<script lang="ts">
+  import {
+    ButtonGroup,
+    Button,
+    Table,
+    TableBody,
+    TableBodyCell,
+    TableBodyRow,
+    TableHead,
+    TableHeadCell,
+  } from 'flowbite-svelte';
+
+  import type { TaskResults } from '$lib/types/task';
+
+  export let taskResults: TaskResults;
+</script>
+
+<!-- TODO: ボタンの並び順を決める -->
+<!-- FIXME: 冗長な記述をリファクタリング -->
+<ButtonGroup class="m-4 contents-center">
+  <Button outline color="primary">ABC</Button>
+  <Button outline color="primary">APG4b</Button>
+  <Button outline color="primary">ABS</Button>
+  <Button outline color="primary">PAST</Button>
+  <Button outline color="primary">Tessoku Book</Button>
+  <Button outline color="primary">Math and Algorithm</Button>
+  <Button outline color="primary">Typical90</Button>
+  <Button outline color="primary">EDPC</Button>
+  <Button outline color="primary">TDPC</Button>
+  <Button outline color="primary">ACL Practice</Button>
+  <Button outline color="primary">JOI</Button>
+</ButtonGroup>
+
+<!-- TODO: 条件に一致する問題をフィルタリングする -->
+<!-- TODO: 該当する問題をテーブル形式で表示する -->
+<div>AtCoder Beginners Contest</div>
+
+<Table shadow hoverable={true}>
+  <TableHead>
+    <TableHeadCell>Contest</TableHeadCell>
+    <TableHeadCell>A</TableHeadCell>
+    <TableHeadCell>B</TableHeadCell>
+    <TableHeadCell>C</TableHeadCell>
+    <TableHeadCell>D</TableHeadCell>
+    <TableHeadCell>E</TableHeadCell>
+    <TableHeadCell>F</TableHeadCell>
+    <TableHeadCell>G</TableHeadCell>
+    <TableHeadCell>H/Ex</TableHeadCell>
+  </TableHead>
+  <TableBody tableBodyClass="divede-y">
+    <TableBodyRow>
+      <TableBodyCell>ABC332</TableBodyCell>
+      <TableBodyCell>A. hoge</TableBodyCell>
+      <TableBodyCell>B. hoge</TableBodyCell>
+      <TableBodyCell>C. hoge</TableBodyCell>
+      <TableBodyCell>D. hoge</TableBodyCell>
+      <TableBodyCell>E. hoge</TableBodyCell>
+      <TableBodyCell>F. hoge</TableBodyCell>
+      <TableBodyCell>G. hoge</TableBodyCell>
+      <TableBodyCell>Ex. hoge</TableBodyCell>
+    </TableBodyRow>
+    <TableBodyRow>
+      <TableBodyCell>ABC331</TableBodyCell>
+      <TableBodyCell>A. hoge</TableBodyCell>
+      <TableBodyCell>B. hoge</TableBodyCell>
+      <TableBodyCell>C. hoge</TableBodyCell>
+      <TableBodyCell>D. hoge</TableBodyCell>
+      <TableBodyCell>E. hoge</TableBodyCell>
+      <TableBodyCell>F. hoge</TableBodyCell>
+      <TableBodyCell>G. hoge</TableBodyCell>
+      <TableBodyCell></TableBodyCell>
+    </TableBodyRow>
+    <TableBodyRow>
+      <TableBodyCell>ABC330</TableBodyCell>
+      <TableBodyCell>A. hoge</TableBodyCell>
+      <TableBodyCell>B. hoge</TableBodyCell>
+      <TableBodyCell>C. hoge</TableBodyCell>
+      <TableBodyCell>D. hoge</TableBodyCell>
+      <TableBodyCell>E. hoge</TableBodyCell>
+      <TableBodyCell>F. hoge</TableBodyCell>
+      <TableBodyCell>G. hoge</TableBodyCell>
+      <TableBodyCell></TableBodyCell>
+    </TableBodyRow>
+  </TableBody>
+</Table>

--- a/src/lib/components/TaskTable.svelte
+++ b/src/lib/components/TaskTable.svelte
@@ -10,76 +10,88 @@
     TableHeadCell,
   } from 'flowbite-svelte';
 
-  import type { TaskResults } from '$lib/types/task';
+  import type { TaskResults, TaskResult } from '$lib/types/task';
+  import { ContestType } from '$lib/types/contest';
+  import { classifyContest, getContestNameLabel } from '$lib/utils/contest';
+  import { getTaskTableHeaderName } from '$lib/utils/task';
 
   export let taskResults: TaskResults;
+
+  let selectedContestType: ContestType;
+  let selectedTaskResults: TaskResults | null = null;
+  let contestNames: Array<string> | null = null;
+  let headerNames: Array<string> | null = null;
+
+  // FIXME: 冗長な記述をリファクタリング
+  // eslint-disable-next-line  @typescript-eslint/no-explicit-any
+  const handleClick = (event: any) => {
+    selectedContestType = event.target.value;
+
+    selectedTaskResults = taskResults.filter(
+      (taskResult: TaskResult) => classifyContest(taskResult.contest_id) === selectedContestType,
+    );
+
+    const contestList = selectedTaskResults.map((taskResult: TaskResult) => taskResult.contest_id);
+    contestNames = Array.from(new Set(contestList)).sort().reverse();
+
+    const headerList = selectedTaskResults.map((taskResult: TaskResult) =>
+      getTaskTableHeaderName(selectedContestType, taskResult),
+    );
+    headerNames = Array.from(new Set(headerList)).sort();
+  };
 </script>
 
 <!-- TODO: ボタンの並び順を決める -->
 <!-- FIXME: 冗長な記述をリファクタリング -->
+<!-- See: -->
+<!-- https://flowbite-svelte.com/docs/components/button-group -->
 <ButtonGroup class="m-4 contents-center">
-  <Button outline color="primary">ABC</Button>
-  <Button outline color="primary">APG4b</Button>
-  <Button outline color="primary">ABS</Button>
-  <Button outline color="primary">PAST</Button>
-  <Button outline color="primary">Tessoku Book</Button>
-  <Button outline color="primary">Math and Algorithm</Button>
-  <Button outline color="primary">Typical90</Button>
-  <Button outline color="primary">EDPC</Button>
-  <Button outline color="primary">TDPC</Button>
-  <Button outline color="primary">ACL Practice</Button>
-  <Button outline color="primary">JOI</Button>
+  <Button outline value={ContestType.ABC} color="primary" on:click={handleClick}>ABC</Button>
+  <Button outline value={ContestType.APG4B} color="primary" on:click={handleClick}>APG4b</Button>
+  <Button outline value={ContestType.ABS} color="primary" on:click={handleClick}>ABS</Button>
+  <Button outline value={ContestType.PAST} color="primary" on:click={handleClick}>PAST</Button>
+  <Button outline value={ContestType.TESSOKU_BOOK} color="primary" on:click={handleClick}>
+    Tessoku Book
+  </Button>
+  <Button outline value={ContestType.MATH_AND_ALGORITHM} color="primary" on:click={handleClick}>
+    Math and Algorithm
+  </Button>
+  <Button outline value={ContestType.TYPICAL90} color="primary" on:click={handleClick}>
+    Typical90
+  </Button>
+  <Button outline value={ContestType.EDPC} color="primary" on:click={handleClick}>EDPC</Button>
+  <Button outline value={ContestType.TDPC} color="primary" on:click={handleClick}>TDPC</Button>
+  <Button outline value={ContestType.ACL_PRACTICE} color="primary" on:click={handleClick}>
+    ACL Practice
+  </Button>
+  <Button outline value={ContestType.JOI} color="primary" on:click={handleClick}>JOI</Button>
 </ButtonGroup>
 
 <!-- TODO: 条件に一致する問題をフィルタリングする -->
 <!-- TODO: 該当する問題をテーブル形式で表示する -->
 <div>AtCoder Beginners Contest</div>
 
+<!-- TODO: 初期状態でABCが選択された状態にする(ライブラリ的に難しい?) -->
+<!-- FIXME: nullの状態のときは表示しないようにする -->
 <Table shadow hoverable={true}>
   <TableHead>
     <TableHeadCell>Contest</TableHeadCell>
-    <TableHeadCell>A</TableHeadCell>
-    <TableHeadCell>B</TableHeadCell>
-    <TableHeadCell>C</TableHeadCell>
-    <TableHeadCell>D</TableHeadCell>
-    <TableHeadCell>E</TableHeadCell>
-    <TableHeadCell>F</TableHeadCell>
-    <TableHeadCell>G</TableHeadCell>
-    <TableHeadCell>H/Ex</TableHeadCell>
+    {#if headerNames !== null && headerNames.length > 0}
+      {#each headerNames as headerName}
+        <TableHeadCell>{headerName}</TableHeadCell>
+      {/each}
+    {/if}
   </TableHead>
   <TableBody tableBodyClass="divede-y">
-    <TableBodyRow>
-      <TableBodyCell>ABC332</TableBodyCell>
-      <TableBodyCell>A. hoge</TableBodyCell>
-      <TableBodyCell>B. hoge</TableBodyCell>
-      <TableBodyCell>C. hoge</TableBodyCell>
-      <TableBodyCell>D. hoge</TableBodyCell>
-      <TableBodyCell>E. hoge</TableBodyCell>
-      <TableBodyCell>F. hoge</TableBodyCell>
-      <TableBodyCell>G. hoge</TableBodyCell>
-      <TableBodyCell>Ex. hoge</TableBodyCell>
-    </TableBodyRow>
-    <TableBodyRow>
-      <TableBodyCell>ABC331</TableBodyCell>
-      <TableBodyCell>A. hoge</TableBodyCell>
-      <TableBodyCell>B. hoge</TableBodyCell>
-      <TableBodyCell>C. hoge</TableBodyCell>
-      <TableBodyCell>D. hoge</TableBodyCell>
-      <TableBodyCell>E. hoge</TableBodyCell>
-      <TableBodyCell>F. hoge</TableBodyCell>
-      <TableBodyCell>G. hoge</TableBodyCell>
-      <TableBodyCell></TableBodyCell>
-    </TableBodyRow>
-    <TableBodyRow>
-      <TableBodyCell>ABC330</TableBodyCell>
-      <TableBodyCell>A. hoge</TableBodyCell>
-      <TableBodyCell>B. hoge</TableBodyCell>
-      <TableBodyCell>C. hoge</TableBodyCell>
-      <TableBodyCell>D. hoge</TableBodyCell>
-      <TableBodyCell>E. hoge</TableBodyCell>
-      <TableBodyCell>F. hoge</TableBodyCell>
-      <TableBodyCell>G. hoge</TableBodyCell>
-      <TableBodyCell></TableBodyCell>
-    </TableBodyRow>
+    {#if contestNames !== null && contestNames.length > 0}
+      <!-- HACK: for ABC only. -->
+      {#if selectedContestType === ContestType.ABC}
+        {#each contestNames as contestName}
+          <TableBodyRow>
+            <TableBodyCell>{getContestNameLabel(contestName)}</TableBodyCell>
+          </TableBodyRow>
+        {/each}
+      {/if}
+    {/if}
   </TableBody>
 </Table>

--- a/src/lib/utils/task.ts
+++ b/src/lib/utils/task.ts
@@ -1,5 +1,19 @@
-import { TaskGrade } from '$lib/types/task';
+import { ContestType } from '$lib/types/contest';
+import { TaskGrade, type TaskResult } from '$lib/types/task';
 
+// See:
+// https://github.com/kenkoooo/AtCoderProblems/blob/master/atcoder-problems-frontend/src/pages/TablePage/AtCoderRegularTable.tsx
+export const getTaskTableHeaderName = (contestType: ContestType, taskResult: TaskResult) => {
+  if (contestType === ContestType.ABC && taskResult.task_table_index === 'H') {
+    return 'H/Ex';
+  } else if (taskResult.task_table_index === 'Ex') {
+    return 'H/Ex';
+  }
+
+  return taskResult.task_table_index;
+};
+
+// FIXME: よりスマートに記述できるようにする
 // https://tailwindcss.com/docs/customizing-colors
 // https://tailwindcss.com/docs/content-configuration#dynamic-class-names
 export const getTaskGradeColor = (grade: string) => {

--- a/src/routes/problems/+page.svelte
+++ b/src/routes/problems/+page.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { ButtonGroup, Button, Tabs, TabItem } from 'flowbite-svelte';
+  import { Tabs, TabItem } from 'flowbite-svelte';
 
   import type { TaskResults, TaskResult } from '$lib/types/task';
   import TaskList from '$lib/components/TaskList.svelte';

--- a/src/routes/problems/+page.svelte
+++ b/src/routes/problems/+page.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
+  import { ButtonGroup, Button, Tabs, TabItem } from 'flowbite-svelte';
+
   import type { TaskResults, TaskResult } from '$lib/types/task';
   import TaskList from '$lib/components/TaskList.svelte';
   import { TaskGrade, taskGradeValues } from '$lib/types/task';
   import { getTaskGradeColor } from '$lib/utils/task';
-
   export let data;
 
   let taskResults: TaskResults = data.taskResults;
@@ -29,17 +30,60 @@
 </script>
 
 <!-- TODO: Searchを追加 -->
-<!-- TODO: コンテスト種類をトグルボタンで切り替えられるようにする -->
-<!-- TODO: Pendingは、Adminのみ表示 -->
 <div class="container mx-auto w-5/6">
   <h1 class="text-3xl">Problems</h1>
-  {#each taskGradeValues as taskGrade}
-    {#if taskResultsForEachGrade.get(taskGrade).length > 0}
-      <TaskList
-        grade={getTaskGradeLabel(taskGrade)}
-        gradeColor={getTaskGradeColor(taskGrade)}
-        taskResults={taskResultsForEachGrade.get(taskGrade)}
-      />
-    {/if}
-  {/each}
+
+  <!-- See: -->
+  <!-- https://flowbite-svelte.com/docs/components/tabs -->
+  <Tabs style="underline" contentClass="bg-white">
+    <TabItem>
+      <span slot="title" class="text-lg">Latest</span>
+      <div class="m-4">Comming Soon.</div>
+    </TabItem>
+
+    <TabItem open>
+      <span slot="title" class="text-lg">Grade</span>
+
+      {#each taskGradeValues as taskGrade}
+        <!-- TODO: Pendingは、Adminのみ表示 -->
+        {#if taskResultsForEachGrade.get(taskGrade).length > 0}
+          <TaskList
+            grade={getTaskGradeLabel(taskGrade)}
+            gradeColor={getTaskGradeColor(taskGrade)}
+            taskResults={taskResultsForEachGrade.get(taskGrade)}
+          />
+        {/if}
+      {/each}
+    </TabItem>
+
+    <!-- TODO: コンテスト種類をトグルボタンで切り替えられるようにする -->
+    <TabItem>
+      <span slot="title" class="text-lg">Table</span>
+
+      <!-- TODO: コンポーネントとして切り出す -->
+      <!-- TODO: ボタンの並び順を決める -->
+      <!-- FIXME: 冗長な記述をリファクタリング -->
+      <ButtonGroup class="m-4 contents-center">
+        <Button outline color="primary">ABC</Button>
+        <Button outline color="primary">APG4b</Button>
+        <Button outline color="primary">ABS</Button>
+        <Button outline color="primary">PAST</Button>
+        <Button outline color="primary">Tessoku Book</Button>
+        <Button outline color="primary">Math and Algorithm</Button>
+        <Button outline color="primary">Typical90</Button>
+        <Button outline color="primary">EDPC</Button>
+        <Button outline color="primary">TDPC</Button>
+        <Button outline color="primary">ACL Practice</Button>
+        <Button outline color="primary">JOI</Button>
+      </ButtonGroup>
+
+      <!-- TODO: 条件に一致する問題をフィルタリングする -->
+      <!-- TODO: 該当する問題をテーブル形式で表示する -->
+    </TabItem>
+
+    <TabItem>
+      <span slot="title" class="text-lg">Tags</span>
+      <div class="m-4">Comming Soon.</div>
+    </TabItem>
+  </Tabs>
 </div>

--- a/src/routes/problems/+page.svelte
+++ b/src/routes/problems/+page.svelte
@@ -3,6 +3,7 @@
 
   import type { TaskResults, TaskResult } from '$lib/types/task';
   import TaskList from '$lib/components/TaskList.svelte';
+  import TaskTable from '$lib/components/TaskTable.svelte';
   import { TaskGrade, taskGradeValues } from '$lib/types/task';
   import { getTaskGradeColor } from '$lib/utils/task';
   export let data;
@@ -60,25 +61,7 @@
     <TabItem>
       <span slot="title" class="text-lg">Table</span>
 
-      <!-- TODO: コンポーネントとして切り出す -->
-      <!-- TODO: ボタンの並び順を決める -->
-      <!-- FIXME: 冗長な記述をリファクタリング -->
-      <ButtonGroup class="m-4 contents-center">
-        <Button outline color="primary">ABC</Button>
-        <Button outline color="primary">APG4b</Button>
-        <Button outline color="primary">ABS</Button>
-        <Button outline color="primary">PAST</Button>
-        <Button outline color="primary">Tessoku Book</Button>
-        <Button outline color="primary">Math and Algorithm</Button>
-        <Button outline color="primary">Typical90</Button>
-        <Button outline color="primary">EDPC</Button>
-        <Button outline color="primary">TDPC</Button>
-        <Button outline color="primary">ACL Practice</Button>
-        <Button outline color="primary">JOI</Button>
-      </ButtonGroup>
-
-      <!-- TODO: 条件に一致する問題をフィルタリングする -->
-      <!-- TODO: 該当する問題をテーブル形式で表示する -->
+      <TaskTable {taskResults} />
     </TabItem>
 
     <TabItem>


### PR DESCRIPTION
## WHAT

- 問題ページにタブを追加し、以下のページを作成できるように準備しています。
  - 新着問題
  - グレード→問題一覧
  - コンテスト→問題一覧
  - タグ→問題一覧

- 進捗状況
  - [ ] ABCを表示するテーブルを作成中
    - [ ] コンテストを新しい順に表示
    - [ ] 問題の表示（実装予定）
  - [ ] 基本的な部分の体裁を修正
  - [ ] デフォルトでABCのボタンが押された状態にしたいが、使用しているライブラリのオプションで指定できない?(確認不足?)
    - 現状では、クリックすると表示される  
  - [ ] コンポーネントのベタ書きややむを得ず使用しているif文などのダーティな部分をリファクタリングしたい 
  - [ ] ボタンの並び順は要相談
  - [ ] 基本的なカラーもそろそろ修正したい