### PR TITLE
:art: Customizable default button colors (#377)

### DIFF
--- a/src/lib/components/SubmissionStatusButton.svelte
+++ b/src/lib/components/SubmissionStatusButton.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  export let value: string;
+  export let textColor: string;
+  export let bgColor: string;
+  export let bgColorOnHover: string;
+  export let labelName: string;
+</script>
+
+<!-- HACK: カスタマイズしやすいボタンコンポーネントを見つけたら差し替える -->
+<!-- WHY: flowbite-svelteでは、同コンポーネントで配色のカスタマイズ・拡張が困難だと思われるため -->
+<button
+  name="submissionStatus"
+  {value}
+  class="{textColor} {bgColor} {bgColorOnHover} border border-gray-300 font-medium rounded-lg shadow-lg shadow-gray500/50 text-sm px-5 py-2.5 me-2 mb-2 w-full max-w-md md:max-w-xl m-3"
+  type="submit"
+>
+  {labelName}
+</button>

--- a/src/lib/services/submission_status.ts
+++ b/src/lib/services/submission_status.ts
@@ -1,29 +1,47 @@
 //import client from '$lib/server/database';
 
+// CI: 提出状況に関するCRUDを実行する部分で原因不明のビルドエラーが発生する
+// 現時点での対処方法: 暫定的にベタ打ちの値を使用
 export const submission_statuses = [
   {
     id: '1',
-    status_name: 'ns',
-    label_name: 'No Sub',
-    image_path: 'ns.png',
-    is_AC: false,
-    button_color: 'light',
-  },
-  {
-    id: '2',
-    status_name: 'wa',
-    label_name: 'WA',
-    image_path: 'wa.png',
-    is_AC: false,
-    button_color: 'yellow',
-  },
-  {
-    id: '3',
     status_name: 'ac',
     label_name: 'AC',
     image_path: 'ac.png',
     is_AC: true,
-    button_color: 'green',
+    text_color: 'text-white', // TODO: Add column and value to schema.
+    button_color: 'bg-atcoder-ac-default', // TODO: Update values in prod DB.
+    button_color_on_hover: 'hover:bg-atcoder-ac-hover', // TODO: Add column and value to schema.
+  },
+  {
+    id: '2',
+    status_name: 'ac_with_editorial',
+    label_name: '解説AC',
+    image_path: 'ac_with_editorial.png',
+    is_AC: true,
+    text_color: 'text-white', // TODO: Add column and value to schema.
+    button_color: 'bg-atcoder-ac-with_editorial-default', // TODO: Update values in prod DB.
+    button_color_on_hover: 'hover:bg-atcoder-ac-with_editorial-hover', // TODO: Add column and value to schema.
+  },
+  {
+    id: '3',
+    status_name: 'wa',
+    label_name: 'WA',
+    image_path: 'wa.png',
+    is_AC: false,
+    text_color: 'text-white', // TODO: Add column and value to schema.
+    button_color: 'bg-atcoder-wa-default', // TODO: Update values in prod DB.
+    button_color_on_hover: 'hover:bg-atcoder-wa-hover', // TODO: Add column and value to schema.
+  },
+  {
+    id: '4',
+    status_name: 'ns',
+    label_name: 'No Sub',
+    image_path: 'ns.png',
+    is_AC: false,
+    text_color: 'text-black', // TODO: Add column and value to schema.
+    button_color: 'bg-atcoder-ns', // TODO: Update values in prod DB.
+    button_color_on_hover: 'hover:bg-gray-100', // TODO: Add column and value to schema.
   },
 ];
 
@@ -38,9 +56,11 @@ export async function getSubmissionStatusMapWithId() {
       id: status.id,
       status_name: status.status_name,
       label_name: status.label_name,
-      button_color: status.button_color,
       image_path: status.image_path,
       is_ac: status.is_AC,
+      text_color: status.text_color,
+      button_color: status.button_color,
+      button_color_on_hover: status.button_color_on_hover,
     });
   });
 

--- a/src/routes/problems/[slug]/+page.svelte
+++ b/src/routes/problems/[slug]/+page.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
   import { enhance } from '$app/forms';
-  import { Button, Breadcrumb, BreadcrumbItem, Img } from 'flowbite-svelte';
+  import { Breadcrumb, BreadcrumbItem, Img } from 'flowbite-svelte';
+
   import { ATCODER_BASE_CONTEST_URL } from '$lib/constants/urls';
+  import SubmissionStatusButton from '$lib/components/SubmissionStatusButton.svelte';
   import ExternalLinkIcon from '$lib/components/ExternalLinkIcon.svelte';
 
   export let data;
@@ -50,22 +52,18 @@
 
   <!-- TODO: Add face icons. -->
   <!-- HACK: flowbite-svelte-icons has few face icon. -->
-  <!-- FIXME: ボタンの色をAtCoder本家に合わせる -->
   <!-- TODO: Add tooltips to buttons for submission results -->
   <!-- See: https://tailwindcss.com/docs/align-items -->
   <!-- See: https://bobbyhadz.com/blog/typescript-type-string-is-not-assignable-to-type -->
   <form method="post" class="flex flex-col items-center" use:enhance>
     {#each buttons as button}
-      <Button
-        name="submissionStatus"
+      <SubmissionStatusButton
         value={button.status_name}
-        color={button.button_color}
-        shadow
-        class="w-full max-w-md md:max-w-xl m-3"
-        type="submit"
-      >
-        {button.label_name}
-      </Button>
+        textColor={button.text_color}
+        bgColor={button.button_color}
+        bgColorOnHover={button.button_color_on_hover}
+        labelName={button.label_name}
+      />
     {/each}
   </form>
 </div>

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -54,6 +54,19 @@ const config = {
           bronze: '',
           silver: '',
           gold: '',
+          ns: '#ffffff',
+          wa: {
+            default: '#f0ad4e',
+            hover: '#d97706',
+          },
+          ac: {
+            default: '#5cb85c',
+            hover: '#449d44',
+            with_editorial: {
+              default: '#00aeef',
+              hover: '#21a0db',
+            },
+          },
         },
       },
     },


### PR DESCRIPTION
@prettyhappycatty 

各問題の回答状況を表すページのボタンの配色をAtCoder本家に合わせました。もし可能であれば、配色やボタンの配置順について、ご意見をいただけますでしょうか?

現状では、flowbite-svelteで任意の色を指定するのは難しい状況です。このため、元となっているtailwind cssのコンポーネントをSvelteコンポーネントとして利用できるようにwrapしています。
これに伴って、ボタンの文字色・背景色（通常時・ホバー時）の指定が必要です。

暫定的なものと認識しているため、DBのスキーマはそのままで、submission_status.tsのsubmission_statusesを一部改変しています。

今後、ユーザがカスタマイズする機能を実装する際には、アプリ側で10種類程度の配色を用意しておくと良いのではないかと考えています（tailwind.config.cjsで事前に指定する必要があるためです。カラーコードをコンポーネントで直接指定できるようになれば、この制約は取り払えるはずです）。

close #377 