### PR TITLE
✨ Enable to delete account from user settings (#365)

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -130,6 +130,8 @@ model TaskTag {
   @@map("tasktag")
 }
 
+// See:
+// https://www.prisma.io/docs/orm/more/upgrade-guides/upgrading-versions/upgrading-to-prisma-3/referential-actions
 model TaskAnswer {
   id        String @unique
   task_id   String
@@ -137,7 +139,7 @@ model TaskAnswer {
   status_id String
 
   task   Task?             @relation(fields: [task_id], references: [task_id])
-  user   User?             @relation(fields: [user_id], references: [id])
+  user   User?             @relation(fields: [user_id], references: [id], onDelete: Cascade)
   status SubmissionStatus? @relation(fields: [status_id], references: [id])
 
   created_at DateTime @default(now())

--- a/src/lib/components/UserAccountDeletionForm.svelte
+++ b/src/lib/components/UserAccountDeletionForm.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+  import { Input, Button, Alert, Checkbox, Li, List } from 'flowbite-svelte';
+  // @ts-ignore
+  import InfoCircleSolid from 'flowbite-svelte-icons/InfoCircleSolid.svelte';
+
+  import ContainerWrapper from '$lib/components/ContainerWrapper.svelte';
+  import FormWrapper from '$lib/components/FormWrapper.svelte';
+  import ReadOnlyLabel from '$lib/components/ReadOnlyLabel.svelte';
+
+  export let username: string;
+
+  let showDeleteButton = false;
+
+  const toggleDeleteButton = () => {
+    showDeleteButton = !showDeleteButton;
+  };
+</script>
+
+<ContainerWrapper>
+  <FormWrapper action="?/delete">
+    <Alert color="red" class="!items-start">
+      <InfoCircleSolid slot="icon" class="w-6 h-6" />
+      <span class="font-medium text-lg">警告</span>
+      <p class="font-medium">以下の内容が削除されます</p>
+
+      <List class="mt-1.5 ms-4 list-disc list-inside">
+        <Li>アカウント</Li>
+        <Li>登録した回答状況</Li>
+        <Li>AtCoder IDとの連携</Li>
+      </List>
+    </Alert>
+
+    <!-- hiddenでusernameを持つのは共通 -->
+    <Input size="sm" type="hidden" name="username" bind:value={username} />
+
+    <ReadOnlyLabel labelName="ユーザ名" inputValue={username} />
+    <Checkbox on:click={toggleDeleteButton}>同意する</Checkbox>
+
+    {#if showDeleteButton}
+      <Button readonly type="submit" class="w-full">アカウントを削除</Button>
+    {/if}
+  </FormWrapper>
+</ContainerWrapper>

--- a/src/routes/users/edit/+page.server.ts
+++ b/src/routes/users/edit/+page.server.ts
@@ -102,16 +102,16 @@ export const actions: Actions = {
     };
   },
 
-  delete: async ({ request }) => {
+  delete: async ({ request, locals }) => {
     console.log('users->actions->delete');
     const formData = await request.formData();
-    console.log(formData);
     const username = formData.get('username')?.toString() as string;
     const atcoder_username = formData.get('atcoder_username')?.toString() as string;
 
-    console.log('TOdoユーザを削除するコードを書きます');
     //const validationCode = await validationService.generate(username, atcoder_username);
     //console.log(validationCode);
+    await userService.deleteUser(username);
+    locals.auth.setSession(null); // remove cookie
 
     return {
       success: true,

--- a/src/routes/users/edit/+page.server.ts
+++ b/src/routes/users/edit/+page.server.ts
@@ -7,9 +7,6 @@ import type { Actions } from './$types';
 
 import { redirect } from '@sveltejs/kit';
 
-//export let action_result = false;
-//export let action_result_message = "";
-
 export async function load({ locals }) {
   const session = await locals.auth.validate();
   if (!session) {
@@ -17,7 +14,6 @@ export async function load({ locals }) {
   }
 
   try {
-    console.log('load');
     const user = await userService.getUser(session?.user.username as string);
 
     return {
@@ -32,7 +28,7 @@ export async function load({ locals }) {
       message: '',
     };
   } catch (e) {
-    console.log("Can't find usrname:", session?.user.username);
+    console.log("Can't find username:", session?.user.username);
     throw redirect(302, '/login');
   }
 }
@@ -41,13 +37,11 @@ export const actions: Actions = {
   generate: async ({ request }) => {
     console.log('users->actions->generate');
     const formData = await request.formData();
-    //console.log(formData);
     const username = formData.get('username')?.toString() as string;
     const atcoder_username = formData.get('atcoder_username')?.toString() as string;
 
     //console.log('ここにvalidationCodeを作成してデータベースに登録するコードを書きます');
     const validationCode = await validationService.generate(username, atcoder_username);
-    //console.log(validationCode);
 
     return {
       success: true,
@@ -61,7 +55,6 @@ export const actions: Actions = {
   validate: async ({ request }) => {
     console.log('users->actions->validate');
     const formData = await request.formData();
-    //console.log(formData);
     const username = formData.get('username')?.toString() as string;
     const atcoder_username = formData.get('atcoder_username')?.toString() as string;
     const atcoder_validationcode = formData.get('atcoder_validationcode')?.toString() as string;
@@ -76,7 +69,7 @@ export const actions: Actions = {
         atcoder_username: atcoder_username,
         atcoder_validationcode: atcoder_validationcode,
         message_type: 'green',
-        message: 'Successfuly validated.',
+        message: 'Successfully validated.',
       },
     };
   },
@@ -84,13 +77,11 @@ export const actions: Actions = {
   reset: async ({ request }) => {
     console.log('users->actions->edit');
     const formData = await request.formData();
-    //console.log(formData);
     const username = formData.get('username')?.toString() as string;
     const atcoder_username = formData.get('atcoder_username')?.toString() as string;
 
     //console.log('AtCoderのユーザ名とValicationCodeをリセットする。');
     const validationCode = await validationService.reset(username);
-    //console.log(validationCode);
 
     return {
       success: true,
@@ -98,7 +89,7 @@ export const actions: Actions = {
       atcoder_username: atcoder_username,
       atcoder_validationcode: validationCode,
       message_type: 'green',
-      message: 'Successfuly reset.',
+      message: 'Successfully reset.',
     };
   },
 
@@ -108,8 +99,6 @@ export const actions: Actions = {
     const username = formData.get('username')?.toString() as string;
     const atcoder_username = formData.get('atcoder_username')?.toString() as string;
 
-    //const validationCode = await validationService.generate(username, atcoder_username);
-    //console.log(validationCode);
     await userService.deleteUser(username);
     locals.auth.setSession(null); // remove cookie
 
@@ -119,7 +108,7 @@ export const actions: Actions = {
       atcoder_username: atcoder_username,
       atcoder_validationcode: false,
       message_type: 'green',
-      message: 'Successfuly deleted.',
+      message: 'Successfully deleted.',
     };
   },
 };

--- a/src/routes/users/edit/+page.svelte
+++ b/src/routes/users/edit/+page.svelte
@@ -1,21 +1,28 @@
 <script lang="ts">
-  import { Tabs, TabItem, Button, Alert } from 'flowbite-svelte';
+  import { Tabs, TabItem, Input, Button, Alert, Checkbox, Li, List } from 'flowbite-svelte';
+  // @ts-ignore
+  import InfoCircleSolid from 'flowbite-svelte-icons/InfoCircleSolid.svelte';
 
   import AtCoderUserValidationForm from '$lib/components/AtCoderUserValidationForm.svelte';
   import ContainerWrapper from '$lib/components/ContainerWrapper.svelte';
   import FormWrapper from '$lib/components/FormWrapper.svelte';
   import ReadOnlyLabel from '$lib/components/ReadOnlyLabel.svelte';
   import SubmissionButton from '$lib/components/SubmissionButton.svelte';
+
+  import { Roles } from '$lib/types/user';
   //import type { ActionForm } from './$types';
   export let data;
   //export let form;
 
+  let role = data.role;
   let username = data.username;
   let atcoder_username = data.atcoder_username;
   let atcoder_validationcode = data.atcoder_validationcode;
   let atcoder_is_validated = data.is_validated;
   let message = data.message;
   let message_type = data.message_type;
+
+  let showDeleteButton = false;
 
   export let status = 'nothing';
   if (data.is_validated === true) {
@@ -24,6 +31,14 @@
   if (data.atcoder_username.length > 0 && data.atcoder_validationcode.length > 0) {
     status = 'generated';
   }
+
+  const isGeneralUser = (userRole: Roles, userName: string) => {
+    return userRole === Roles.USER && userName !== 'guest';
+  };
+
+  const toggleDeleteButton = () => {
+    showDeleteButton = !showDeleteButton;
+  };
 </script>
 
 {#if message_type === 'default'}
@@ -86,15 +101,37 @@
       </TabItem>
     {/if}
 
-    <!-- アカウント削除 -->
-    <TabItem>
-      <span slot="title" class="text-lg">アカウント削除</span>
-      <ContainerWrapper>
-        <FormWrapper action="/users/delete">
-          <ReadOnlyLabel labelName="ユーザ名" inputValue={username} />
-          <Button disabled readonly type="submit" class="w-full">アカウントを削除</Button>
-        </FormWrapper>
-      </ContainerWrapper>
-    </TabItem>
+    <!-- アカウント削除 (ゲストを除いた一般ユーザのみ) -->
+    {#if isGeneralUser(role, username)}
+      <TabItem>
+        <span slot="title" class="text-lg">アカウント削除</span>
+        <!-- TODO: コンポーネントとして切り出す -->
+        <ContainerWrapper>
+          <FormWrapper action="?/delete">
+            <Alert color="red" class="!items-start">
+              <InfoCircleSolid slot="icon" class="w-6 h-6" />
+              <span class="font-medium text-lg">警告</span>
+              <p class="font-medium">以下の内容が削除されます</p>
+
+              <List class="mt-1.5 ms-4 list-disc list-inside">
+                <Li>アカウント</Li>
+                <Li>登録した回答状況</Li>
+                <Li>AtCoder IDとの連携</Li>
+              </List>
+            </Alert>
+
+            <!-- hiddenでusernameを持つのは共通 -->
+            <Input size="sm" type="hidden" name="username" bind:value={username} />
+
+            <ReadOnlyLabel labelName="ユーザ名" inputValue={username} />
+            <Checkbox on:click={toggleDeleteButton}>同意する</Checkbox>
+
+            {#if showDeleteButton}
+              <Button readonly type="submit" class="w-full">アカウントを削除</Button>
+            {/if}
+          </FormWrapper>
+        </ContainerWrapper>
+      </TabItem>
+    {/if}
   </Tabs>
 </div>

--- a/src/routes/users/edit/+page.svelte
+++ b/src/routes/users/edit/+page.svelte
@@ -1,18 +1,16 @@
 <script lang="ts">
-  import { Tabs, TabItem, Input, Button, Alert, Checkbox, Li, List } from 'flowbite-svelte';
-  // @ts-ignore
-  import InfoCircleSolid from 'flowbite-svelte-icons/InfoCircleSolid.svelte';
+  import { Tabs, TabItem, Alert } from 'flowbite-svelte';
 
   import AtCoderUserValidationForm from '$lib/components/AtCoderUserValidationForm.svelte';
+  import UserAccountDeletionForm from '$lib/components/UserAccountDeletionForm.svelte';
   import ContainerWrapper from '$lib/components/ContainerWrapper.svelte';
   import FormWrapper from '$lib/components/FormWrapper.svelte';
   import ReadOnlyLabel from '$lib/components/ReadOnlyLabel.svelte';
   import SubmissionButton from '$lib/components/SubmissionButton.svelte';
 
   import { Roles } from '$lib/types/user';
-  //import type { ActionForm } from './$types';
+
   export let data;
-  //export let form;
 
   let role = data.role;
   let username = data.username;
@@ -21,8 +19,6 @@
   let atcoder_is_validated = data.is_validated;
   let message = data.message;
   let message_type = data.message_type;
-
-  let showDeleteButton = false;
 
   export let status = 'nothing';
   if (data.is_validated === true) {
@@ -34,10 +30,6 @@
 
   const isGeneralUser = (userRole: Roles, userName: string) => {
     return userRole === Roles.USER && userName !== 'guest';
-  };
-
-  const toggleDeleteButton = () => {
-    showDeleteButton = !showDeleteButton;
   };
 </script>
 
@@ -105,32 +97,7 @@
     {#if isGeneralUser(role, username)}
       <TabItem>
         <span slot="title" class="text-lg">アカウント削除</span>
-        <!-- TODO: コンポーネントとして切り出す -->
-        <ContainerWrapper>
-          <FormWrapper action="?/delete">
-            <Alert color="red" class="!items-start">
-              <InfoCircleSolid slot="icon" class="w-6 h-6" />
-              <span class="font-medium text-lg">警告</span>
-              <p class="font-medium">以下の内容が削除されます</p>
-
-              <List class="mt-1.5 ms-4 list-disc list-inside">
-                <Li>アカウント</Li>
-                <Li>登録した回答状況</Li>
-                <Li>AtCoder IDとの連携</Li>
-              </List>
-            </Alert>
-
-            <!-- hiddenでusernameを持つのは共通 -->
-            <Input size="sm" type="hidden" name="username" bind:value={username} />
-
-            <ReadOnlyLabel labelName="ユーザ名" inputValue={username} />
-            <Checkbox on:click={toggleDeleteButton}>同意する</Checkbox>
-
-            {#if showDeleteButton}
-              <Button readonly type="submit" class="w-full">アカウントを削除</Button>
-            {/if}
-          </FormWrapper>
-        </ContainerWrapper>
+        <UserAccountDeletionForm {username} />
       </TabItem>
     {/if}
   </Tabs>


### PR DESCRIPTION
@prettyhappycatty 

お久しぶりです。
ユーザアカウントの削除機能を実装しています。お手隙の際に、レビューをお願いできますでしょうか?

Refs #365

## 実装の概略

- アカウントの削除が可能なユーザ
  - 一般ユーザ（guestを除く） 
- データの削除範囲
  - ユーザテーブル（アカウント情報）
  - cascadeでセッション、パスワード、回答状況も削除
  - AtCoder ID（設定ページから連携している場合）
- ユーザーの個人ページに削除ボタンを追加
- 復元が困難な操作であることがUIから分かるようにする
  - 警告メッセージを追加
- ほんとうに削除しますか？の確認
  - モーダルを利用して確認メッセージを表示→削除としたいですが、モーダルからdeleteアクションが動作せず
  - 暫定的な対処: 「同意」のチェックボックスを用意し、同意したときだけ、削除ボタンが表示されるようにしています  

## 重点的に確認していただきたい点

- UIから復元困難な操作であることが伝わるか?
- 誤操作をしづらいUIか?

## 課題

- アカウントの削除中は、loading状態であることがユーザにも分かるようにする
- モーダルを利用して、アカウントの削除の意向を確認できるようにする
- アカウントの削除後に、操作が完了したことをポップアップで表示する