### PR TITLE
:bug: Revert flowbite-svelte from 0.46.11 to 0.46.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "eslint": "8.57.0",
     "eslint-config-prettier": "9.1.0",
     "eslint-plugin-svelte": "2.41.0",
-    "flowbite-svelte": "0.46.11",
+    "flowbite-svelte": "0.46.6",
     "flowbite-svelte-icons": "0.4.4",
     "husky": "9.0.11",
     "jsdom": "24.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,8 +115,8 @@ importers:
         specifier: 2.41.0
         version: 2.41.0(eslint@8.57.0)(svelte@4.2.18)(ts-node@10.9.1(@types/node@16.18.11)(typescript@5.5.2))
       flowbite-svelte:
-        specifier: 0.46.11
-        version: 0.46.11(rollup@4.18.0)(svelte@4.2.18)
+        specifier: 0.46.6
+        version: 0.46.6(rollup@4.18.0)(svelte@4.2.18)
       flowbite-svelte-icons:
         specifier: 0.4.4
         version: 0.4.4(svelte@4.2.18)(tailwind-merge@1.14.0)(tailwindcss@3.4.4(ts-node@10.9.1(@types/node@16.18.11)(typescript@5.5.2)))
@@ -2243,8 +2243,8 @@ packages:
       tailwind-merge: ^1.13.2
       tailwindcss: ^3.3.2
 
-  flowbite-svelte@0.46.11:
-    resolution: {integrity: sha512-kZB1J7S+AB9TWT4mmMvV2EZIM8G0JiVab6YVao49d1Y4X3jnfbNhxsyttlFGRHBFbRfEI3pFR5FetOTa4REP2g==}
+  flowbite-svelte@0.46.6:
+    resolution: {integrity: sha512-SUK+JpjVM/EeZ+bsfhEPFCzNpH2vgR8eHiRE02VmSkgKfucHcZEV16kSWaZMlDYR89N+J+/oBGyiuZ/KZ/xzXA==}
     engines: {node: '>=18.0.0', pnpm: '>=8.0.0'}
     peerDependencies:
       svelte: ^3.55.1 || ^4.0.0
@@ -6492,7 +6492,7 @@ snapshots:
       tailwind-merge: 1.14.0
       tailwindcss: 3.4.4(ts-node@10.9.1(@types/node@16.18.11)(typescript@5.5.2))
 
-  flowbite-svelte@0.46.11(rollup@4.18.0)(svelte@4.2.18):
+  flowbite-svelte@0.46.6(rollup@4.18.0)(svelte@4.2.18):
     dependencies:
       '@floating-ui/dom': 1.6.6
       apexcharts: 3.49.2


### PR DESCRIPTION
close #929

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Downgraded the version of "flowbite-svelte" from "0.46.11" to "0.46.6" for compatibility and stability improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->