### PR TITLE
🚨 Add tests for task grade label (#1037)

### DIFF
--- a/src/test/lib/utils/task.test.ts
+++ b/src/test/lib/utils/task.test.ts
@@ -5,9 +5,10 @@ import {
   countAllTasks,
   areAllTasksAccepted,
   compareByContestIdAndTaskId,
+  getTaskGradeLabel,
 } from '$lib/utils/task';
 import type { WorkBookTaskBase } from '$lib/types/workbook';
-import type { TaskResult, TaskResults } from '$lib/types/task';
+import { type TaskResult, type TaskResults, TaskGrade } from '$lib/types/task';
 
 import {
   taskResultsForUserId2,
@@ -40,6 +41,13 @@ type TestCaseForSortingTaskResults = {
 };
 
 type TestCasesForSortingTaskResults = TestCaseForSortingTaskResults[];
+
+type TestCaseForTaskGradeLabel = {
+  taskGrade: TaskGrade | string;
+  expected: TaskGrade | string;
+};
+
+type TestCasesForTaskGradeLabel = TestCaseForTaskGradeLabel[];
 
 describe('Task', () => {
   describe('count accepted tasks', () => {
@@ -452,6 +460,65 @@ describe('Task', () => {
         `${testName}(first: $first.task_id, second: $second.task_id)`,
         testFunction,
       );
+    }
+  });
+
+  describe('get task grade label', () => {
+    describe('when task grades are given', () => {
+      const testCases: TestCasesForTaskGradeLabel = [
+        {
+          taskGrade: TaskGrade.Q11,
+          expected: '11Q',
+        },
+        {
+          taskGrade: TaskGrade.Q10,
+          expected: '10Q',
+        },
+        {
+          taskGrade: TaskGrade.Q9,
+          expected: '9Q',
+        },
+        {
+          taskGrade: TaskGrade.Q2,
+          expected: '2Q',
+        },
+        {
+          taskGrade: TaskGrade.Q1,
+          expected: '1Q',
+        },
+        {
+          taskGrade: TaskGrade.D1,
+          expected: '1D',
+        },
+        {
+          taskGrade: TaskGrade.D2,
+          expected: '2D',
+        },
+        {
+          taskGrade: TaskGrade.D6,
+          expected: '6D',
+        },
+      ];
+
+      runTests(
+        'getTaskGradeLabel',
+        testCases,
+        ({ taskGrade, expected }: TestCaseForTaskGradeLabel) => {
+          expect(getTaskGradeLabel(taskGrade)).toEqual(expected);
+        },
+      );
+    });
+
+    test('when pending is given', () => {
+      expect(getTaskGradeLabel(TaskGrade.PENDING)).toEqual(TaskGrade.PENDING);
+    });
+
+    function runTests(
+      testName: string,
+      testCases: TestCasesForTaskGradeLabel,
+      testFunction: (testCase: TestCaseForTaskGradeLabel) => void,
+    ) {
+      test.each(testCases)(`${testName}(taskGrade: $taskGrade)`, testFunction);
     }
   });
 });


### PR DESCRIPTION
close #1037

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new test suite for validating task grade labels, enhancing the testing coverage for task grading functionality.
	- Implemented test cases for various task grades, including handling of standard and distinct grades, as well as pending tasks. 

- **Bug Fixes**
	- Improved the correctness of the `getTaskGradeLabel` function through comprehensive testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->