### PR TITLE
:art: Show main and replenished workbooks for curriculum in different table (#1046)

### DIFF
--- a/prisma/ERD.md
+++ b/prisma/ERD.md
@@ -164,6 +164,7 @@ OTHERS OTHERS
     String description 
     Boolean isPublished 
     Boolean isOfficial 
+    Boolean isReplenished 
     WorkBookType workBookType 
     DateTime createdAt 
     DateTime updatedAt 

--- a/prisma/migrations/20240806043908_add_is_replenished_to_workbook/migration.sql
+++ b/prisma/migrations/20240806043908_add_is_replenished_to_workbook/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "workbook" ADD COLUMN     "isReplenished" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -169,15 +169,16 @@ model SubmissionStatus {
 }
 
 model WorkBook {
-  id           Int          @id @default(autoincrement())
-  authorId     String
-  title        String
-  description  String       @default("")
-  isPublished  Boolean      @default(false)
-  isOfficial   Boolean      @default(false)
-  workBookType WorkBookType @default(CREATED_BY_USER)
-  createdAt    DateTime     @default(now())
-  updatedAt    DateTime     @updatedAt
+  id            Int          @id @default(autoincrement())
+  authorId      String
+  title         String
+  description   String       @default("")
+  isPublished   Boolean      @default(false)
+  isOfficial    Boolean      @default(false)
+  isReplenished Boolean      @default(false) // カリキュラムの【補充】を識別するために使用
+  workBookType  WorkBookType @default(CREATED_BY_USER)
+  createdAt     DateTime     @default(now())
+  updatedAt     DateTime     @updatedAt
 
   user User @relation(references: [id], fields: [authorId])
 

--- a/src/lib/components/WorkBooks/WorkBookBaseTable.svelte
+++ b/src/lib/components/WorkBooks/WorkBookBaseTable.svelte
@@ -40,6 +40,8 @@
   }
 </script>
 
+<!-- HACK: 2024年8月時点では「ユーザ作成」の問題集のみ大きく仕様が異なるので、暫定的に条件分岐で対処 -->
+<!-- HACK: 「解説別」と含めて仕様が大幅に変更される可能性が高いので、保留にしている -->
 <div class="overflow-auto rounded-md border">
   <Table shadow class="text-md">
     <TableHead class="text-sm bg-gray-100">

--- a/src/lib/components/WorkBooks/WorkBookBaseTable.svelte
+++ b/src/lib/components/WorkBooks/WorkBookBaseTable.svelte
@@ -1,0 +1,137 @@
+<script lang="ts">
+  import { enhance } from '$app/forms';
+
+  import {
+    Table,
+    TableBody,
+    TableBodyCell,
+    TableBodyRow,
+    TableHead,
+    TableHeadCell,
+  } from 'flowbite-svelte';
+
+  import { WorkBookType, type WorkbooksList } from '$lib/types/workbook';
+  import { TaskGrade, type TaskGradeRange, type TaskResults } from '$lib/types/task';
+  import type { Roles } from '$lib/types/user';
+
+  import GradeLabel from '$lib/components/GradeLabel.svelte';
+  import PublicationStatusLabel from '$lib/components/WorkBooks/PublicationStatusLabel.svelte';
+  import CompletedTasks from '$lib/components/Trophies/CompletedTasks.svelte';
+  import ThermometerProgressBar from '$lib/components/ThermometerProgressBar.svelte';
+  import AcceptedCounter from '$lib/components/SubmissionStatus/AcceptedCounter.svelte';
+
+  import { canRead, canEdit, canDelete } from '$lib/utils/authorship';
+
+  export let workbookType: WorkBookType;
+  export let workbooks: WorkbooksList;
+  export let workbookGradeRanges: Map<number, TaskGradeRange>;
+  export let userId: string;
+  export let role: Roles;
+  export let taskResults: Map<number, TaskResults>;
+
+  function getGradeLower(workbookId: number): TaskGrade {
+    const workbookGradeRange = workbookGradeRanges.get(workbookId);
+
+    return workbookGradeRange?.lower ?? TaskGrade.PENDING;
+  }
+
+  function getTaskResult(workbookId: number): TaskResults {
+    return taskResults?.get(workbookId) ?? [];
+  }
+</script>
+
+<div class="overflow-auto rounded-md border">
+  <Table shadow class="text-md">
+    <TableHead class="text-sm bg-gray-100">
+      {#if workbookType === WorkBookType.CREATED_BY_USER}
+        <TableHeadCell>作者</TableHeadCell>
+      {:else}
+        <TableHeadCell class="text-center px-0">
+          <div>グレード</div>
+        </TableHeadCell>
+      {/if}
+      <TableHeadCell
+        class="text-left min-w-[240px] max-w-[240px] lg:max-w-[280px] xl:max-w-[360px] 2xl:max-w-[480px] px-1 xs:px-3"
+      >
+        タイトル
+      </TableHeadCell>
+      <TableHeadCell class="ext-left min-w-[240px] max-w-[1440px] px-0">回答状況</TableHeadCell>
+      <TableHeadCell></TableHeadCell>
+      <TableHeadCell class="text-center px-0">修了</TableHeadCell>
+      <TableHeadCell></TableHeadCell>
+    </TableHead>
+
+    <TableBody tableBodyClass="divide-y">
+      {#each workbooks as workbook}
+        {#if canRead(workbook.isPublished, userId, workbook.authorId)}
+          <TableBodyRow>
+            {#if workbookType === WorkBookType.CREATED_BY_USER}
+              <TableBodyCell>
+                <div class="truncate min-w-[96px] max-w-[120px]">
+                  {workbook.authorName}
+                </div>
+              </TableBodyCell>
+            {:else}
+              <TableBodyCell class="justify-center w-14 px-2">
+                <div class="flex items-center justify-center min-w-[54px] max-w-[54px]">
+                  <GradeLabel taskGrade={getGradeLower(workbook.id)} />
+                </div>
+              </TableBodyCell>
+            {/if}
+            <TableBodyCell class="w-2/5 pl-2 xs:pl-4 pr-4">
+              <div
+                class="flex items-center space-x-2 truncate min-w-[240px] max-w-[240px] lg:max-w-[300px] xl:max-w-[380px] 2xl:max-w-[480px]"
+              >
+                <PublicationStatusLabel isPublished={workbook.isPublished} />
+                <a
+                  href="/workbooks/{workbook.id}"
+                  class="flex-1 font-medium xs:text-lg text-primary-600 hover:underline dark:text-primary-500 truncate"
+                >
+                  {workbook.title}
+                </a>
+              </div>
+            </TableBodyCell>
+            <TableBodyCell class="min-w-[240px] max-w-[1440px] px-0">
+              <ThermometerProgressBar
+                workBookTasks={workbook.workBookTasks}
+                taskResults={getTaskResult(workbook.id)}
+                width="w-full"
+              />
+            </TableBodyCell>
+            <TableBodyCell class="justify-center w-24 px-1">
+              <div class="min-w-[48px] max-w-[96px]">
+                <AcceptedCounter
+                  workBookTasks={workbook.workBookTasks}
+                  taskResults={getTaskResult(workbook.id)}
+                />
+              </div>
+            </TableBodyCell>
+            <TableBodyCell tdClass="justify-center items-center min-w-[54px] max-w-[54px]">
+              <div class="flex justify-center items-center">
+                <CompletedTasks
+                  taskResults={getTaskResult(workbook.id)}
+                  allTasks={workbook.workBookTasks}
+                />
+              </div>
+            </TableBodyCell>
+            <TableBodyCell class="justify-center w-24 px-0">
+              <div
+                class="flex justify-center items-center space-x-3 min-w-[96px] max-w-[120px] text-gray-700 dark:text-gray-300"
+              >
+                {#if canEdit(userId, workbook.authorId, role, workbook.isPublished)}
+                  <a href="/workbooks/edit/{workbook.id}">編集</a>
+                {/if}
+
+                {#if canDelete(userId, workbook.authorId)}
+                  <form method="POST" action="?/delete&slug={workbook.id}" use:enhance>
+                    <button>削除</button>
+                  </form>
+                {/if}
+              </div>
+            </TableBodyCell>
+          </TableBodyRow>
+        {/if}
+      {/each}
+    </TableBody>
+  </Table>
+</div>

--- a/src/lib/components/WorkBooks/WorkBookInputFields.svelte
+++ b/src/lib/components/WorkBooks/WorkBookInputFields.svelte
@@ -4,11 +4,13 @@
   import SelectWrapper from '$lib/components/SelectWrapper.svelte';
   import { WorkBookType } from '$lib/types/workbook';
 
+  // FIXME: 引数がとても多いので、コンポーネントに渡す引数を減らす方法を調べて実装。
   export let authorId: string;
   export let workBookTitle: string;
   export let description: string;
   export let isPublished: boolean;
   export let isOfficial: boolean;
+  export let isReplenished: boolean;
   export let workBookType: WorkBookType;
   export let isAdmin: boolean;
   export let isEditable: boolean = true;
@@ -18,6 +20,11 @@
   let isPublishedOptions = [
     { value: false, name: '非公開' },
     { value: true, name: '公開' },
+  ];
+
+  let isReplenishedOptions = [
+    { value: false, name: '本編' },
+    { value: true, name: '補充' },
   ];
 
   const workBookTypeOptions = (isOfficial: boolean, isAdmin: boolean = false) => {
@@ -38,6 +45,8 @@
       return allWorkBookTypes.filter((type) => type.value === WorkBookType.CREATED_BY_USER);
     }
   };
+
+  $: isCurriculum = workBookType === WorkBookType.TEXTBOOK;
 </script>
 
 <MessageHelperWrapper {message} />
@@ -85,11 +94,21 @@
   isEditable={false}
 />
 
-<!-- 管理者のみ: 問題集の区分を指定-->
+<!-- 管理者のみ: 問題集の種類を指定-->
 <SelectWrapper
-  labelName="問題集の区分"
+  labelName="問題集の種類"
   innerName="workBookType"
   items={workBookTypeOptions(isOfficial, isAdmin)}
   bind:inputValue={workBookType}
   isEditable={isAdmin && isEditable}
+/>
+
+<!-- HACK: 表記については修正の余地がある -->
+<!-- 管理者のみ: 問題集が本編 / 補充か -->
+<SelectWrapper
+  labelName="問題集の位置付け"
+  innerName="isReplenished"
+  items={isReplenishedOptions}
+  bind:inputValue={isReplenished}
+  isEditable={isAdmin && isEditable && isCurriculum}
 />

--- a/src/lib/components/WorkBooks/WorkBookList.svelte
+++ b/src/lib/components/WorkBooks/WorkBookList.svelte
@@ -1,30 +1,16 @@
 <script lang="ts">
-  import { enhance } from '$app/forms';
   import { get } from 'svelte/store';
 
-  import {
-    ButtonGroup,
-    Button,
-    Table,
-    TableBody,
-    TableBodyCell,
-    TableBodyRow,
-    TableHead,
-    TableHeadCell,
-  } from 'flowbite-svelte';
+  import { ButtonGroup, Button } from 'flowbite-svelte';
 
   import { taskGradesByWorkBookTypeStore } from '$lib/stores/task_grades_by_workbook_type';
-  import { canRead, canEdit, canDelete } from '$lib/utils/authorship';
+  import { canRead } from '$lib/utils/authorship';
   import { WorkBookType, type WorkbookList, type WorkbooksList } from '$lib/types/workbook';
   import { getTaskGradeLabel } from '$lib/utils/task';
   import { TaskGrade, type TaskGradeRange, type TaskResults } from '$lib/types/task';
   import type { Roles } from '$lib/types/user';
   import TooltipWrapper from '$lib/components/TooltipWrapper.svelte';
-  import GradeLabel from '$lib/components/GradeLabel.svelte';
-  import PublicationStatusLabel from '$lib/components/WorkBooks/PublicationStatusLabel.svelte';
-  import CompletedTasks from '$lib/components/Trophies/CompletedTasks.svelte';
-  import ThermometerProgressBar from '$lib/components/ThermometerProgressBar.svelte';
-  import AcceptedCounter from '$lib/components/SubmissionStatus/AcceptedCounter.svelte';
+  import WorkBookBaseTable from '$lib/components/WorkBooks/WorkBookBaseTable.svelte';
 
   export let workbookType: WorkBookType;
   export let workbooks: WorkbooksList;
@@ -71,10 +57,6 @@
 
     return workbookGradeRange?.lower ?? TaskGrade.PENDING;
   }
-
-  function getTaskResult(workbookId: number): TaskResults {
-    return taskResultsWithWorkBookId?.get(workbookId) ?? [];
-  }
 </script>
 
 <!-- TODO: 6Q〜1Q?にも対応 -->
@@ -100,101 +82,14 @@
 {/if}
 
 {#if readableWorkbooksCount}
-  <div class="overflow-auto rounded-md border">
-    <Table shadow class="text-md">
-      <TableHead class="text-sm bg-gray-100">
-        {#if workbookType === WorkBookType.CREATED_BY_USER}
-          <TableHeadCell>作者</TableHeadCell>
-        {:else}
-          <TableHeadCell class="text-center px-0">
-            <div>グレード</div>
-          </TableHeadCell>
-        {/if}
-        <TableHeadCell
-          class="text-left min-w-[240px] max-w-[240px] lg:max-w-[280px] xl:max-w-[360px] 2xl:max-w-[480px] px-1 xs:px-3"
-        >
-          タイトル
-        </TableHeadCell>
-        <TableHeadCell class="ext-left min-w-[240px] max-w-[1440px] px-0">回答状況</TableHeadCell>
-        <TableHeadCell></TableHeadCell>
-        <TableHeadCell class="text-center px-0">修了</TableHeadCell>
-        <TableHeadCell></TableHeadCell>
-      </TableHead>
-
-      <TableBody tableBodyClass="divide-y">
-        {#each filteredWorkbooks as workbook}
-          {#if canRead(workbook.isPublished, userId, workbook.authorId)}
-            <TableBodyRow>
-              {#if workbookType === WorkBookType.CREATED_BY_USER}
-                <TableBodyCell>
-                  <div class="truncate min-w-[96px] max-w-[120px]">
-                    {workbook.authorName}
-                  </div>
-                </TableBodyCell>
-              {:else}
-                <TableBodyCell class="justify-center w-14 px-2">
-                  <div class="flex items-center justify-center min-w-[54px] max-w-[54px]">
-                    <GradeLabel taskGrade={getGradeLower(workbook.id)} />
-                  </div>
-                </TableBodyCell>
-              {/if}
-              <TableBodyCell class="w-2/5 pl-2 xs:pl-4 pr-4">
-                <div
-                  class="flex items-center space-x-2 truncate min-w-[240px] max-w-[240px] lg:max-w-[300px] xl:max-w-[380px] 2xl:max-w-[480px]"
-                >
-                  <PublicationStatusLabel isPublished={workbook.isPublished} />
-                  <a
-                    href="/workbooks/{workbook.id}"
-                    class="flex-1 font-medium xs:text-lg text-primary-600 hover:underline dark:text-primary-500 truncate"
-                  >
-                    {workbook.title}
-                  </a>
-                </div>
-              </TableBodyCell>
-              <TableBodyCell class="min-w-[240px] max-w-[1440px] px-0">
-                <ThermometerProgressBar
-                  workBookTasks={workbook.workBookTasks}
-                  taskResults={getTaskResult(workbook.id)}
-                  width="w-full"
-                />
-              </TableBodyCell>
-              <TableBodyCell class="justify-center w-24 px-1">
-                <div class="min-w-[48px] max-w-[96px]">
-                  <AcceptedCounter
-                    workBookTasks={workbook.workBookTasks}
-                    taskResults={getTaskResult(workbook.id)}
-                  />
-                </div>
-              </TableBodyCell>
-              <TableBodyCell tdClass="justify-center items-center min-w-[54px] max-w-[54px]">
-                <div class="flex justify-center items-center">
-                  <CompletedTasks
-                    taskResults={getTaskResult(workbook.id)}
-                    allTasks={workbook.workBookTasks}
-                  />
-                </div>
-              </TableBodyCell>
-              <TableBodyCell class="justify-center w-24 px-0">
-                <div
-                  class="flex justify-center items-center space-x-3 min-w-[96px] max-w-[120px] text-gray-700 dark:text-gray-300"
-                >
-                  {#if canEdit(userId, workbook.authorId, role, workbook.isPublished)}
-                    <a href="/workbooks/edit/{workbook.id}">編集</a>
-                  {/if}
-
-                  {#if canDelete(userId, workbook.authorId)}
-                    <form method="POST" action="?/delete&slug={workbook.id}" use:enhance>
-                      <button>削除</button>
-                    </form>
-                  {/if}
-                </div>
-              </TableBodyCell>
-            </TableBodyRow>
-          {/if}
-        {/each}
-      </TableBody>
-    </Table>
-  </div>
+  <WorkBookBaseTable
+    {workbookType}
+    workbooks={filteredWorkbooks}
+    {workbookGradeRanges}
+    {userId}
+    {role}
+    taskResults={taskResultsWithWorkBookId}
+  />
 {:else}
   <div>該当する問題集は見つかりませんでした。</div>
   <div>新しい問題集が追加されるまで、しばらくお待ちください。</div>

--- a/src/lib/services/workbooks.ts
+++ b/src/lib/services/workbooks.ts
@@ -1,8 +1,8 @@
 import { default as db } from '$lib/server/database';
-import type { WorkBook, WorkBookTaskBase, WorkBookType } from '$lib/types/workbook';
+import type { WorkBook, WorkBooks, WorkBookTaskBase, WorkBookType } from '$lib/types/workbook';
 import { getWorkBookTasks, validateRequiredFields } from '$lib/services/workbook_tasks';
 
-export async function getWorkBooks() {
+export async function getWorkBooks(): Promise<WorkBooks> {
   const workbooks = await db.workBook.findMany({
     orderBy: {
       id: 'asc',
@@ -15,7 +15,7 @@ export async function getWorkBooks() {
   return workbooks;
 }
 
-export async function getWorkBook(workBookId: number) {
+export async function getWorkBook(workBookId: number): Promise<WorkBook | null> {
   const workBook = await db.workBook.findUnique({
     where: {
       id: workBookId,
@@ -30,7 +30,7 @@ export async function getWorkBook(workBookId: number) {
 
 // See:
 // https://www.prisma.io/docs/orm/prisma-schema/data-model/relations#create-a-record-and-nested-records
-export async function createWorkBook(workBook: WorkBook) {
+export async function createWorkBook(workBook: WorkBook): Promise<void> {
   const newWorkBookTasks: WorkBookTaskBase[] = await getWorkBookTasks(workBook);
   const newWorkBook = await db.workBook.create({
     data: {
@@ -39,6 +39,7 @@ export async function createWorkBook(workBook: WorkBook) {
       description: workBook.description,
       isPublished: workBook.isPublished,
       isOfficial: workBook.isOfficial,
+      isReplenished: workBook.isReplenished,
       workBookType: workBook.workBookType as WorkBookType,
       workBookTasks: {
         create: newWorkBookTasks,
@@ -52,7 +53,7 @@ export async function createWorkBook(workBook: WorkBook) {
   console.log(newWorkBook);
 }
 
-async function isExistingWorkBook(workBookId: number) {
+async function isExistingWorkBook(workBookId: number): Promise<boolean> {
   const workBook = await getWorkBook(workBookId);
 
   if (workBook) {
@@ -62,7 +63,7 @@ async function isExistingWorkBook(workBookId: number) {
   }
 }
 
-export async function updateWorkBook(workBookId: number, workBook: WorkBook) {
+export async function updateWorkBook(workBookId: number, workBook: WorkBook): Promise<void> {
   if (!(await isExistingWorkBook(workBookId))) {
     throw new Error(`Not found WorkBook with id ${workBookId}.`);
   }
@@ -95,7 +96,7 @@ export async function updateWorkBook(workBookId: number, workBook: WorkBook) {
   }
 }
 
-export async function deleteWorkBook(workBookId: number) {
+export async function deleteWorkBook(workBookId: number): Promise<void> {
   if (!(await isExistingWorkBook(workBookId))) {
     throw new Error(`Not found WorkBook with id ${workBookId}.`);
   }

--- a/src/lib/types/workbook.ts
+++ b/src/lib/types/workbook.ts
@@ -5,6 +5,7 @@ export type WorkBookBase = {
   description: string;
   isPublished: boolean;
   isOfficial: boolean;
+  isReplenished: boolean; // カリキュラムの【補充】を識別するために使用
   workBookType: WorkBookType;
   workBookTasks: WorkBookTaskBase[];
 };

--- a/src/lib/zod/schema.ts
+++ b/src/lib/zod/schema.ts
@@ -38,6 +38,7 @@ export const workBookSchema = z.object({
     .max(300, { message: '300文字になるまで削除してください' }),
   isPublished: z.boolean(),
   isOfficial: z.boolean(),
+  isReplenished: z.boolean(), // カリキュラムの【補充】を識別するために使用
   workBookType: z.nativeEnum(WorkBookType),
   workBookTasks: z
     .array(workBookTaskSchema)

--- a/src/routes/workbooks/create/+page.svelte
+++ b/src/routes/workbooks/create/+page.svelte
@@ -57,6 +57,7 @@
       bind:description={$form.description}
       bind:isPublished={$form.isPublished}
       bind:isOfficial={$form.isOfficial}
+      bind:isReplenished={$form.isReplenished}
       bind:workBookType={$form.workBookType}
       isAdmin={data.isAdmin}
       message={$message}

--- a/src/routes/workbooks/edit/[slug]/+page.svelte
+++ b/src/routes/workbooks/edit/[slug]/+page.svelte
@@ -72,6 +72,7 @@
         bind:description={$form.description}
         bind:isPublished={$form.isPublished}
         bind:isOfficial={$form.isOfficial}
+        bind:isReplenished={$form.isReplenished}
         bind:workBookType={$form.workBookType}
         isAdmin={data.loggedInAsAdmin}
         message={$message}


### PR DESCRIPTION
close #1046

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new property, `isReplenished`, for tracking the replenishment status of workbooks.
	- Added a new Svelte component, `WorkBookBaseTable`, for displaying workbook data in a structured table format.
	- Enhanced form functionalities to include `isReplenished` binding for better data handling during workbook creation and editing.

- **Improvements**
	- Improved filtering and display logic for distinguishing between main and replenished workbooks.

- **Bug Fixes**
	- Adjusted UI elements for clarity, ensuring a better user experience when classifying workbooks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->