### PR TITLE
✨ Add topic editorial url to workbooks (#1026)

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,8 @@
     "svelte-eslint-parser": "^0.41.0",
     "tailwind-merge": "1.14.0",
     "tailwindcss": "3.4.8",
-    "vercel": "35.2.3"
+    "vercel": "35.2.3",
+    "xss": "1.0.15"
   },
   "packageManager": "pnpm@9.1.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       vercel:
         specifier: 35.2.3
         version: 35.2.3
+      xss:
+        specifier: 1.0.15
+        version: 1.0.15
     devDependencies:
       '@playwright/test':
         specifier: 1.46.0
@@ -1389,6 +1392,9 @@ packages:
     resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
     engines: {node: '>=18'}
 
+  commander@2.20.3:
+    resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
+
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
@@ -1447,6 +1453,9 @@ packages:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
     hasBin: true
+
+  cssfilter@0.0.10:
+    resolution: {integrity: sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw==}
 
   cssstyle@4.0.1:
     resolution: {integrity: sha512-8ZYiJ3A/3OkDd093CBT/0UKDWry7ak4BdPTFP2+QEP7cmhouyq/Up709ASSj2cK02BbZiMgk7kYjZNS4QP5qrQ==}
@@ -1732,8 +1741,8 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
-  dompurify@3.1.4:
-    resolution: {integrity: sha512-2gnshi6OshmuKil8rMZuQCGiUF3cUxHY3NGDzUAdUx/NPEe5DVnO8BDoAQouvgwnx0R/+a6jUn36Z0FSdq8vww==}
+  dompurify@3.1.6:
+    resolution: {integrity: sha512-cTOAhc36AalkjtBpfG6O8JimdTMWNXjiePT2xQH/ppBGi/4uIpmj8eKyIkMJErXWARyINV/sB38yf8JCLF5pbQ==}
 
   domutils@3.1.0:
     resolution: {integrity: sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==}
@@ -4101,6 +4110,11 @@ packages:
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
+  xss@1.0.15:
+    resolution: {integrity: sha512-FVdlVVC67WOIPvfOwhoMETV72f6GbW7aOabBC3WxN/oUdoEMDyLz4OgRv5/gck2ZeNqEQu+Tb0kloovXOfpYVg==}
+    engines: {node: '>= 0.10.0'}
+    hasBin: true
+
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
@@ -5530,6 +5544,8 @@ snapshots:
 
   commander@12.1.0: {}
 
+  commander@2.20.3: {}
+
   commander@4.1.1: {}
 
   commander@7.2.0: {}
@@ -5579,6 +5595,8 @@ snapshots:
   css.escape@1.5.1: {}
 
   cssesc@3.0.0: {}
+
+  cssfilter@0.0.10: {}
 
   cssstyle@4.0.1:
     dependencies:
@@ -5852,7 +5870,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.1.4: {}
+  dompurify@3.1.6: {}
 
   domutils@3.1.0:
     dependencies:
@@ -6845,7 +6863,7 @@ snapshots:
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.10
       dayjs: 1.11.11
-      dompurify: 3.1.4
+      dompurify: 3.1.6
       elkjs: 0.9.3
       katex: 0.16.10
       khroma: 2.1.0
@@ -8350,6 +8368,11 @@ snapshots:
   xml-name-validator@5.0.0: {}
 
   xmlchars@2.2.0: {}
+
+  xss@1.0.15:
+    dependencies:
+      commander: 2.20.3
+      cssfilter: 0.0.10
 
   y18n@5.0.8: {}
 

--- a/prisma/ERD.md
+++ b/prisma/ERD.md
@@ -162,6 +162,7 @@ OTHERS OTHERS
     String authorId 
     String title 
     String description 
+    String editorialUrl 
     Boolean isPublished 
     Boolean isOfficial 
     Boolean isReplenished 

--- a/prisma/migrations/20240808004755_add_editorial_url_to_workbooks/migration.sql
+++ b/prisma/migrations/20240808004755_add_editorial_url_to_workbooks/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "workbook" ADD COLUMN     "editorialUrl" TEXT NOT NULL DEFAULT '';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -173,6 +173,7 @@ model WorkBook {
   authorId      String
   title         String
   description   String       @default("")
+  editorialUrl  String       @default("") // カリキュラムのトピック解説用のURL。HACK: 「ユーザ作成」の場合も利用できるようにするかは要検討。
   isPublished   Boolean      @default(false)
   isOfficial    Boolean      @default(false)
   isReplenished Boolean      @default(false) // カリキュラムの【補充】を識別するために使用

--- a/src/lib/components/WorkBooks/WorkBookInputFields.svelte
+++ b/src/lib/components/WorkBooks/WorkBookInputFields.svelte
@@ -8,6 +8,7 @@
   export let authorId: string;
   export let workBookTitle: string;
   export let description: string;
+  export let editorialUrl: string;
   export let isPublished: boolean;
   export let isOfficial: boolean;
   export let isReplenished: boolean;
@@ -75,6 +76,16 @@
   bind:inputValue={description}
   {isEditable}
   message={errors.description}
+/>
+
+<!-- カリキュラムのトピック解説用のURL -->
+<!-- HACK: 「ユーザ作成」の場合も利用できるようにするかは要検討。 -->
+<InputFieldWrapper
+  labelName="トピックの解説URL（300文字以下）"
+  inputFieldName="editorialUrl"
+  bind:inputValue={editorialUrl}
+  {isEditable}
+  message={errors.editorialUrl}
 />
 
 <!-- 一般公開の有無 -->

--- a/src/lib/services/workbooks.ts
+++ b/src/lib/services/workbooks.ts
@@ -1,6 +1,7 @@
 import { default as db } from '$lib/server/database';
 import type { WorkBook, WorkBooks, WorkBookTaskBase, WorkBookType } from '$lib/types/workbook';
 import { getWorkBookTasks, validateRequiredFields } from '$lib/services/workbook_tasks';
+import { sanitizeUrl } from '$lib/utils/url';
 
 export async function getWorkBooks(): Promise<WorkBooks> {
   const workbooks = await db.workBook.findMany({
@@ -31,12 +32,15 @@ export async function getWorkBook(workBookId: number): Promise<WorkBook | null> 
 // See:
 // https://www.prisma.io/docs/orm/prisma-schema/data-model/relations#create-a-record-and-nested-records
 export async function createWorkBook(workBook: WorkBook): Promise<void> {
+  const sanitizedUrl = sanitizeUrl(workBook.editorialUrl);
   const newWorkBookTasks: WorkBookTaskBase[] = await getWorkBookTasks(workBook);
+
   const newWorkBook = await db.workBook.create({
     data: {
       authorId: workBook.authorId,
       title: workBook.title,
       description: workBook.description,
+      editorialUrl: sanitizedUrl,
       isPublished: workBook.isPublished,
       isOfficial: workBook.isOfficial,
       isReplenished: workBook.isReplenished,

--- a/src/lib/types/workbook.ts
+++ b/src/lib/types/workbook.ts
@@ -3,6 +3,7 @@ import type { WorkBookType as WorkBookTypeOrigin } from '@prisma/client';
 export type WorkBookBase = {
   title: string;
   description: string;
+  editorialUrl: string; // カリキュラムのトピック解説用のURL。HACK: 「ユーザ作成」の場合も利用できるようにするかは要検討。
   isPublished: boolean;
   isOfficial: boolean;
   isReplenished: boolean; // カリキュラムの【補充】を識別するために使用

--- a/src/lib/utils/url.ts
+++ b/src/lib/utils/url.ts
@@ -1,0 +1,19 @@
+import xss from 'xss';
+
+export function isValidUrl(rawUrl: string): boolean {
+  const pattern = new RegExp(
+    '^(?:' + // start
+      '(https?:\\/\\/)?' + // protocol (https:// or http://)
+      '(([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.?)+[a-z]{2,}' + // domain name
+      '(\\/[-a-z\\d%_.~+]*)*' + // path
+      '(\\?[;&a-z\\d%_.~+=-]*)?' + // query string
+      ')?$', // end
+    'i',
+  );
+
+  return !!pattern.test(rawUrl);
+}
+
+export function sanitizeUrl(rawUrl: string) {
+  return xss(rawUrl);
+}

--- a/src/lib/zod/schema.ts
+++ b/src/lib/zod/schema.ts
@@ -4,6 +4,7 @@
 // https://qiita.com/mpyw/items/886218e7b418dfed254b
 import { z } from 'zod';
 import { WorkBookType } from '$lib/types/workbook';
+import { isValidUrl } from '$lib/utils/url';
 
 export const authSchema = z.object({
   username: z
@@ -36,6 +37,11 @@ export const workBookSchema = z.object({
     .string()
     .min(0, { message: '' })
     .max(300, { message: '300文字になるまで削除してください' }),
+  editorialUrl: z
+    .string()
+    .min(0, { message: '' })
+    .max(300, { message: '300文字になるまで削除してください' })
+    .refine(isValidUrl, { message: 'URLを再入力してください' }), // カリキュラムのトピック解説用のURL。HACK: 「ユーザ作成」の場合も利用できるようにするかは要検討。
   isPublished: z.boolean(),
   isOfficial: z.boolean(),
   isReplenished: z.boolean(), // カリキュラムの【補充】を識別するために使用

--- a/src/routes/workbooks/[slug]/+page.svelte
+++ b/src/routes/workbooks/[slug]/+page.svelte
@@ -94,12 +94,25 @@
     </BreadcrumbItem>
   </Breadcrumb>
 
-  {#if workBook.description !== ''}
-    <div class="pt-3 pb-6">
-      <div class="text-2xl font-bold">概要</div>
-      <div class="min-w-[240px] max-w-[1440px] truncate">
-        {workBook.description}
-      </div>
+  {#if workBook.description !== '' || workBook.editorialUrl !== ''}
+    <div class="pt-3 pb-6 space-y-4">
+      {#if workBook.description !== ''}
+        <div>
+          <div class="text-2xl font-bold">概要</div>
+          <div class="min-w-[240px] max-w-[1440px] truncate">
+            {workBook.description}
+          </div>
+        </div>
+      {/if}
+
+      {#if workBook.editorialUrl !== ''}
+        <div>
+          <div class="text-2xl font-bold">トピックの解説</div>
+          <div class="min-w-[240px] max-w-[1440px] truncate">
+            <ExternalLinkWrapper url={workBook.editorialUrl} description="外部リンク" />
+          </div>
+        </div>
+      {/if}
     </div>
   {/if}
 

--- a/src/routes/workbooks/create/+page.svelte
+++ b/src/routes/workbooks/create/+page.svelte
@@ -55,6 +55,7 @@
       bind:authorId={$form.authorId}
       bind:workBookTitle={$form.title}
       bind:description={$form.description}
+      bind:editorialUrl={$form.editorialUrl}
       bind:isPublished={$form.isPublished}
       bind:isOfficial={$form.isOfficial}
       bind:isReplenished={$form.isReplenished}

--- a/src/routes/workbooks/edit/[slug]/+page.svelte
+++ b/src/routes/workbooks/edit/[slug]/+page.svelte
@@ -70,6 +70,7 @@
         bind:authorId={$form.authorId}
         bind:workBookTitle={$form.title}
         bind:description={$form.description}
+        bind:editorialUrl={$form.editorialUrl}
         bind:isPublished={$form.isPublished}
         bind:isOfficial={$form.isOfficial}
         bind:isReplenished={$form.isReplenished}

--- a/src/test/lib/utils/url.test.ts
+++ b/src/test/lib/utils/url.test.ts
@@ -1,0 +1,118 @@
+import { expect, test } from 'vitest';
+
+import { isValidUrl, sanitizeUrl } from '$lib/utils/url';
+
+type TestCaseForUrlValidation = {
+  rawUrl: string;
+};
+
+type TestCasesForUrlValidation = TestCaseForUrlValidation[];
+
+type TestCaseForUrlSanitization = {
+  rawUrl: string;
+  expected: string;
+};
+
+type TestCasesForUrlSanitization = TestCaseForUrlSanitization[];
+
+describe('URL', () => {
+  describe('is valid URL', () => {
+    describe('when valid URL are given', () => {
+      const testCases = [
+        { rawUrl: 'https://atcoder.jp' },
+        { rawUrl: 'https://atcoder.jp/contests/abc365/editorial/10586' },
+        { rawUrl: 'https://drken1215.hatenablog.com' },
+        { rawUrl: 'https://drken1215.hatenablog.com/entry/2023/06/11/123536' },
+        { rawUrl: 'https://qiita.com/e869120' },
+        { rawUrl: 'https://qiita.com/e869120/items/f1c6f98364d1443148b3' },
+      ];
+
+      runTests('isValidUrl', testCases, ({ rawUrl }: TestCaseForUrlValidation) => {
+        expect(isValidUrl(rawUrl)).toBeTruthy();
+      });
+    });
+
+    test('when an empty URL is given', () => {
+      expect(isValidUrl('')).toBeTruthy();
+    });
+
+    describe('when invalid URL are given', () => {
+      const testCases = [
+        { rawUrl: 'htt://' },
+        { rawUrl: 'example.c' },
+        // Note: 記事のセクション(#マーク)を含む場合は、2024年8月時点では無効なURLとして処理。ユーザの要望が多ければ、修正。
+        {
+          rawUrl:
+            'https://qiita.com/e869120/items/f1c6f98364d1443148b3#1-2-5-%E3%82%B3%E3%83%9F%E3%83%A5%E3%83%8B%E3%83%86%E3%82%A3%E3%83%BC%E3%81%8C%E5%84%AA%E3%81%97%E3%81%84',
+        },
+      ];
+
+      runTests('isValidUrl', testCases, ({ rawUrl }: TestCaseForUrlValidation) => {
+        expect(isValidUrl(rawUrl)).toBeFalsy();
+      });
+    });
+
+    function runTests(
+      testName: string,
+      testCases: TestCasesForUrlValidation,
+      testFunction: (testCase: TestCaseForUrlValidation) => void,
+    ) {
+      test.each(testCases)(`${testName}(rawUrl: $rawUrl)`, testFunction);
+    }
+  });
+
+  describe('sanitize URL', () => {
+    describe('when sanitization is not required URLs are given', () => {
+      const testCases = [
+        { rawUrl: 'https://atcoder.jp', expected: 'https://atcoder.jp' },
+        {
+          rawUrl: 'https://atcoder.jp/contests/abc365/editorial/10586',
+          expected: 'https://atcoder.jp/contests/abc365/editorial/10586',
+        },
+        {
+          rawUrl: 'https://drken1215.hatenablog.com',
+          expected: 'https://drken1215.hatenablog.com',
+        },
+        {
+          rawUrl: 'https://drken1215.hatenablog.com/entry/2023/06/11/123536',
+          expected: 'https://drken1215.hatenablog.com/entry/2023/06/11/123536',
+        },
+        { rawUrl: 'https://qiita.com/e869120', expected: 'https://qiita.com/e869120' },
+        {
+          rawUrl: 'https://qiita.com/e869120/items/f1c6f98364d1443148b3',
+          expected: 'https://qiita.com/e869120/items/f1c6f98364d1443148b3',
+        },
+      ];
+
+      runTests('sanitizeUrl', testCases, ({ rawUrl, expected }: TestCaseForUrlSanitization) => {
+        expect(sanitizeUrl(rawUrl)).toEqual(expected);
+      });
+    });
+
+    // HACK: テストケースが弱いと思われるので、有効なケースが用意できれば追加する。
+    describe('when sanitization is required URLs are given', () => {
+      const testCases = [
+        {
+          rawUrl: '<script>alert("XSS")</script><div>Safe content</div>',
+          expected: '&lt;script&gt;alert("XSS")&lt;/script&gt;<div>Safe content</div>',
+        },
+        {
+          rawUrl: 'https://<script>alert("XSS")</script>.hatenablog.com',
+          expected: 'https://&lt;script&gt;alert("XSS")&lt;/script&gt;.hatenablog.com',
+        },
+      ];
+
+      runTests('sanitizeUrl', testCases, ({ rawUrl, expected }: TestCaseForUrlSanitization) => {
+        expect(sanitizeUrl(rawUrl)).toEqual(expected);
+      });
+    });
+
+    function runTests(
+      testName: string,
+      testCases: TestCasesForUrlSanitization,
+      testFunction: (testCase: TestCaseForUrlSanitization) => void,
+    ) {
+      test.each(testCases)(`${testName}(rawUrl: $rawUrl)`, testFunction);
+    }
+  });
+});


### PR DESCRIPTION
close #1026

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for `editorialUrl` in workbooks, allowing users to input URLs related to editorial content.
	- Introduced URL validation and sanitization functions to enhance security and data integrity.

- **Bug Fixes**
	- Improved handling of user input for workbook URLs to prevent invalid entries.

- **Tests**
	- Added unit tests to ensure the reliability and security of URL validation and sanitization functionalities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->