### PR TITLE
:bug: Make sure that workbook tasks are displayed in order of priority (#1138)

### DIFF
--- a/src/lib/services/workbooks.ts
+++ b/src/lib/services/workbooks.ts
@@ -9,7 +9,11 @@ export async function getWorkBooks(): Promise<WorkBooks> {
       id: 'asc',
     },
     include: {
-      workBookTasks: true,
+      workBookTasks: {
+        orderBy: {
+          priority: 'asc',
+        },
+      },
     },
   });
 
@@ -58,7 +62,7 @@ export async function createWorkBook(workBook: WorkBook): Promise<void> {
     },
   });
 
-  console.log(newWorkBook);
+  console.log(`Created workbook with title: ${newWorkBook.title}`);
 }
 
 async function isExistingWorkBook(workBookId: number): Promise<boolean> {
@@ -99,7 +103,10 @@ export async function updateWorkBook(workBookId: number, workBook: WorkBook): Pr
 
     console.log(await getWorkBook(workBookId));
   } catch (error) {
-    console.error(`Failed to update WorkBook with id ${workBookId}:`, error);
+    console.error(
+      `Failed to update WorkBook with id ${workBookId} and title ${workBook.title}:`,
+      error,
+    );
     throw error;
   }
 }

--- a/src/lib/services/workbooks.ts
+++ b/src/lib/services/workbooks.ts
@@ -22,7 +22,11 @@ export async function getWorkBook(workBookId: number): Promise<WorkBook | null> 
       id: workBookId,
     },
     include: {
-      workBookTasks: true,
+      workBookTasks: {
+        orderBy: {
+          priority: 'asc',
+        },
+      },
     },
   });
 


### PR DESCRIPTION
close #1138 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Improved task retrieval by prioritizing associated tasks in ascending order when fetching workbooks.
	- Enhanced logging for workbook creation with descriptive messages including the workbook title.
	
- **Bug Fixes**
	- Improved error handling in workbook updates to include workbook titles in error messages for better context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->