### PR TITLE
🔧 Add Node.js v20 to CI (#258)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [18.x]
+        node-version: [18.x, 20.x]
 
     steps:
       - name: Check out Git repository


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the CI workflow to support multiple Node.js versions (18.x and 20.x) for improved testing and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->