### PR TITLE
✨ Enable to import contest (#1464)

### DIFF
--- a/src/lib/utils/contest.ts
+++ b/src/lib/utils/contest.ts
@@ -128,6 +128,22 @@ const ATCODER_UNIVERSITIES: ContestPrefix = {
 
 const atCoderUniversityPrefixes = getContestPrefixes(ATCODER_UNIVERSITIES);
 
+/**
+ * Maps other AtCoder contest ID prefixes to their display names.
+ * Includes special, corporate, and promotional contests that don't fit other categories.
+ *
+ * @example
+ * {
+ *   'mujin-pc-2018': 'Mujin Programming Challenge 2018',
+ *   'discovery2016': 'DISCO presents ディスカバリーチャンネル プログラミングコンテスト2016'
+ * }
+ *
+ * @remarks
+ * When adding new contests:
+ * 1. Use kebab-case for contest ID prefix as key
+ * 2. Use official contest name in English or Japanese as value
+ * 3. Ensure the contest doesn't belong to other specific categories
+ */
 const ATCODER_OTHERS: ContestPrefix = {
   chokudai_S: 'Chokudai SpeedRun',
   'code-festival-2014-final': 'Code Festival 2014 決勝',

--- a/src/lib/utils/contest.ts
+++ b/src/lib/utils/contest.ts
@@ -133,6 +133,7 @@ const ATCODER_OTHERS: ContestPrefix = {
   'code-festival-2014-final': 'Code Festival 2014 決勝',
   donuts: 'Donutsプロコンチャレンジ',
   'mujin-pc-2016': 'Mujin Programming Challenge 2016',
+  'mujin-pc-2018': 'Mujin Programming Challenge 2018',
   'tenka1-2016-final': '天下一プログラマーコンテスト2016本戦',
   // Discovery Channel contest featuring algorithm problems
   discovery2016: 'DISCO presents ディスカバリーチャンネル プログラミングコンテスト2016',

--- a/src/test/lib/utils/test_cases/contest_type.ts
+++ b/src/test/lib/utils/test_cases/contest_type.ts
@@ -262,6 +262,10 @@ export const atCoderOthers = [
     contestId: 'mujin-pc-2016',
     expected: ContestType.OTHERS,
   }),
+  createTestCaseForContestType('MUJIN Programming Challenge 2018')({
+    contestId: 'mujin-pc-2018',
+    expected: ContestType.OTHERS,
+  }),
   createTestCaseForContestType('天下一プログラマーコンテスト2016本戦')({
     contestId: 'tenka1-2016-final',
     expected: ContestType.OTHERS,


### PR DESCRIPTION
close #1464

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for the "Mujin Programming Challenge 2018" contest, enhancing the system's contest classification capabilities.
  
- **Documentation**
	- Updated documentation for the `ATCODER_OTHERS` constant to provide guidelines for adding new contests.

- **Tests**
	- Introduced a new test case for the "Mujin Programming Challenge 2018" to ensure proper classification and functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->