### PR TITLE
:books: Update external links (#1512)

### DIFF
--- a/src/lib/constants/external-links.ts
+++ b/src/lib/constants/external-links.ts
@@ -3,7 +3,7 @@ import {
   ATCODER_PROBLEMS_URL,
   AOJ_ATCODER_JOI_URL,
   AOJ_PCK_URL,
-  AOJ_ICPC_URL,
+  ICPC_JAPAN_PROBLEMS_URL,
   GITHUB_URL,
 } from './urls';
 
@@ -12,6 +12,6 @@ export const externalLinks = [
   { title: `AtCoder Problems`, path: ATCODER_PROBLEMS_URL },
   { title: `AOJ / AtCoder-JOI`, path: AOJ_ATCODER_JOI_URL },
   { title: `AOJ-PCK`, path: AOJ_PCK_URL },
-  { title: `AOJ-ICPC`, path: AOJ_ICPC_URL },
+  { title: `ICPC Japan Problems`, path: ICPC_JAPAN_PROBLEMS_URL },
   { title: `GitHub`, path: GITHUB_URL },
 ];

--- a/src/lib/constants/urls.ts
+++ b/src/lib/constants/urls.ts
@@ -8,9 +8,6 @@ export const ATCODER_PROBLEMS_API_BASE_URL: string = 'https://kenkoooo.com/atcod
 
 export const AOJ_API_BASE_URL: string = 'https://judgeapi.u-aizu.ac.jp/';
 
-// 注:
-// AIZU ONLINE JUDGE (AOJ) では、v1.0, v2.0, v3.0のサイトが存在する。
-// 2024年10月下旬時点でメインサイトだと思われるv2.0を使用する。
 // Note:
 // AIZU ONLINE JUDGE (AOJ) has multiple versions: v1.0, v2.0, and v3.0.
 // As of late October 2024, we are using v2.0, which appears to be the main site.
@@ -22,6 +19,6 @@ export const AOJ_ATCODER_JOI_URL: string = 'https://joi.goodbaton.com/';
 
 export const AOJ_PCK_URL: string = 'https://pro-ktmr.github.io/aoj-pck/';
 
-export const AOJ_ICPC_URL: string = 'http://aoj-icpc.ichyo.jp/';
+export const ICPC_JAPAN_PROBLEMS_URL: string = 'https://icpc-japan-problems.irrrrr.cc/';
 
 export const GITHUB_URL: string = 'https://github.com/AtCoder-NoviSteps/AtCoderNoviSteps';


### PR DESCRIPTION
close #1512

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated external links to include a new URL for ICPC Japan Problems.
	- Removed the old AOJ ICPC URL and replaced it with the new ICPC Japan Problems URL.
- **Bug Fixes**
	- Corrected the title and path for the ICPC link in the external links array.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->