### PR TITLE
🔧 Add Node.js v22 to CI (#1488)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [20.x, 22.x]
 
     steps:
       - name: Check out Git repository


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced CI workflow to support multiple Node.js versions (20.x and 22.x).
  - Added steps for handling database migrations and improved deployment process to Vercel.

- **Improvements**
  - Ensured latest patch version of Node.js 20 is used in preview builds.
  - Implemented conditional staging domain assignment for preview deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->