### PR TITLE
📖 Update License (#1615)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 - 2024 AtCoder NoviSteps
+Copyright (c) 2023 - 2025 AtCoder NoviSteps
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
close #1615

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the copyright year in the LICENSE file from 2024 to 2025 for AtCoder NoviSteps

<!-- end of auto-generated comment: release notes by coderabbit.ai -->