### PR TITLE
:art: Hide replenished workbooks by default (#1708)

### DIFF
--- a/src/lib/components/WorkBooks/WorkBookList.svelte
+++ b/src/lib/components/WorkBooks/WorkBookList.svelte
@@ -57,7 +57,7 @@
   });
   $: readableReplenishedWorkbooksCount = () => countReadableWorkbooks(replenishedWorkbooks);
 
-  let isShowReplenishment: boolean = true;
+  let isShowReplenishment: boolean = false;
 
   function countReadableWorkbooks(workbooks: WorkbooksList): number {
     const results = workbooks.reduce((count, workbook: WorkbookList) => {


### PR DESCRIPTION
close #1708

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
	- The workbook list now defaults to hiding replenished workbooks, giving users a cleaner initial view. Users can toggle the display if needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->