### PR TITLE
:art: Allow saving and restoring of showing/hiding of replenishment workbook for curriculum (#1726)

### DIFF
--- a/src/lib/components/WorkBooks/WorkBookList.svelte
+++ b/src/lib/components/WorkBooks/WorkBookList.svelte
@@ -103,27 +103,21 @@
 <!-- TODO: 「ユーザ作成」の問題集には、検索機能を追加 -->
 {#if workbookType === WorkBookType.CURRICULUM}
   <div class="mb-6">
-    <div class="flex flex-col md:flex-row items-start md:items-center justify-between">
-      <div class="flex items-center space-x-4">
-        <ButtonGroup>
-          {#each AVAILABLE_GRADES as grade}
-            <Button
-              onclick={() => filterByGradeMode(grade)}
-              class={selectedGrade === grade ? 'text-primary-700' : 'text-gray-900'}
-            >
-              {getTaskGradeLabel(grade)}
-            </Button>
-          {/each}
-        </ButtonGroup>
+    <div class="flex items-center space-x-4">
+      <ButtonGroup>
+        {#each AVAILABLE_GRADES as grade}
+          <Button
+            onclick={() => filterByGradeMode(grade)}
+            class={selectedGrade === grade ? 'text-primary-700' : 'text-gray-900'}
+          >
+            {getTaskGradeLabel(grade)}
+          </Button>
+        {/each}
+      </ButtonGroup>
 
-        <TooltipWrapper
-          tooltipContent="問題集のグレードを指定します（最頻値。2つ以上ある場合は、最も易しいグレードに掲載）"
-        />
-      </div>
-
-      <div class="mt-4 md:mt-0">
-        <Toggle bind:checked={isShowReplenishment}>「補充」があれば表示</Toggle>
-      </div>
+      <TooltipWrapper
+        tooltipContent="問題集のグレードを指定します（最頻値。2つ以上ある場合は、最も易しいグレードに掲載）"
+      />
     </div>
   </div>
 {/if}
@@ -144,31 +138,40 @@
     />
   </div>
 
-  <!-- カリキュラムの場合、かつ、公開されている【補充】問題集があるときだけ表示 -->
-  {#if workbookType === WorkBookType.CURRICULUM && readableReplenishedWorkbooksCount() && isShowReplenishment}
+  <!-- カリキュラム、かつ、公開されている【補充】問題集があるときのみ -->
+  {#if workbookType === WorkBookType.CURRICULUM && readableReplenishedWorkbooksCount()}
     <div class="mt-12">
-      <div class="flex items-center space-x-3 pb-4">
-        <div class="text-2xl dark:text-white">補充</div>
+      <!-- 見出しと説明文、表示の切り替え用ボタンを常に表示 -->
+      <div class="flex flex-col md:flex-row items-start md:items-center md:space-x-6">
+        <div class="flex items-center space-x-1 pb-0 md:pb-4">
+          <div class="text-2xl dark:text-white">補充</div>
 
-        <LabelWithTooltips
-          labelName=""
-          tooltipId="tooltip-for-replenished-workbooks"
-          tooltipContents={[
-            '（任意）',
-            '特定の課題を持つ人向けの問題集です。',
-            '苦手意識があれば、挑戦してみましょう。',
-          ]}
-        />
+          <LabelWithTooltips
+            labelName=""
+            tooltipId="tooltip-for-replenished-workbooks"
+            tooltipContents={[
+              '（任意）',
+              '特定の課題（数学的素養や実装力など）を持つ人向けの問題集です。',
+              '苦手意識があれば、挑戦してみましょう。',
+            ]}
+          />
+        </div>
+
+        <div class="mt-4 md:mt-0 pb-4">
+          <Toggle bind:checked={isShowReplenishment}>表示</Toggle>
+        </div>
       </div>
 
-      <WorkBookBaseTable
-        {workbookType}
-        workbooks={replenishedWorkbooks}
-        {workbookGradeModes}
-        {userId}
-        {role}
-        taskResults={taskResultsWithWorkBookId}
-      />
+      {#if isShowReplenishment}
+        <WorkBookBaseTable
+          {workbookType}
+          workbooks={replenishedWorkbooks}
+          {workbookGradeModes}
+          {userId}
+          {role}
+          taskResults={taskResultsWithWorkBookId}
+        />
+      {/if}
     </div>
   {/if}
 {:else}

--- a/src/lib/components/WorkBooks/WorkBookList.svelte
+++ b/src/lib/components/WorkBooks/WorkBookList.svelte
@@ -160,8 +160,9 @@
           <Toggle
             checked={replenishmentWorkBooksStore.canView()}
             onclick={replenishmentWorkBooksStore.toggleView}
+            aria-label="Toggle visibility of replenishment workbooks for curriculum"
           >
-            表示
+            問題集を表示
           </Toggle>
         </div>
       </div>

--- a/src/lib/components/WorkBooks/WorkBookList.svelte
+++ b/src/lib/components/WorkBooks/WorkBookList.svelte
@@ -4,6 +4,7 @@
   import { ButtonGroup, Button, Toggle } from 'svelte-5-ui-lib';
 
   import { taskGradesByWorkBookTypeStore } from '$lib/stores/task_grades_by_workbook_type';
+  import { replenishmentWorkBooksStore } from '$lib/stores/replenishment_workbook.svelte';
   import { canRead } from '$lib/utils/authorship';
   import { WorkBookType, type WorkbookList, type WorkbooksList } from '$lib/types/workbook';
   import { getTaskGradeLabel } from '$lib/utils/task';
@@ -56,8 +57,6 @@
       return gradeMode === selectedGrade && workbook.isReplenished;
     }),
   );
-
-  let isShowReplenishment: boolean = $state(false);
 
   function countReadableWorkbooks(workbooks: WorkbooksList): number {
     const results = workbooks.reduce((count, workbook: WorkbookList) => {
@@ -158,11 +157,16 @@
         </div>
 
         <div class="mt-4 md:mt-0 pb-4">
-          <Toggle bind:checked={isShowReplenishment}>表示</Toggle>
+          <Toggle
+            checked={replenishmentWorkBooksStore.canView()}
+            onclick={replenishmentWorkBooksStore.toggleView}
+          >
+            表示
+          </Toggle>
         </div>
       </div>
 
-      {#if isShowReplenishment}
+      {#if replenishmentWorkBooksStore.canView()}
         <WorkBookBaseTable
           {workbookType}
           workbooks={replenishedWorkbooks}

--- a/src/lib/stores/replenishment_workbook.svelte.ts
+++ b/src/lib/stores/replenishment_workbook.svelte.ts
@@ -1,0 +1,43 @@
+// See:
+// https://svelte.dev/docs/kit/$app-environment#browser
+import { browser } from '$app/environment';
+
+// See:
+// https://svelte.dev/docs/svelte/stores
+// https://svelte.dev/docs/svelte/$state
+const IS_SHOWN_REPLENISHMENT_WORKBOOKS = 'is_shown_replenishment_workbooks';
+
+class ReplenishmentWorkBooksStore {
+  private isShown = $state<boolean>(this.loadInitialState());
+
+  // Note:
+  // The $state only manages state in memory and is reset on page reload.
+  // In addition, it is not linked to the browser's persistent storage.
+  private loadInitialState(): boolean {
+    // WHY: Cannot access localStorage during SSR (server-side rendering).
+    if (!browser) {
+      return false;
+    }
+
+    const savedStatus = localStorage.getItem(IS_SHOWN_REPLENISHMENT_WORKBOOKS);
+    return savedStatus ? JSON.parse(savedStatus) : false;
+  }
+
+  canView() {
+    return this.isShown;
+  }
+
+  toggleView = () => {
+    this.isShown = !this.isShown;
+
+    if (browser) {
+      localStorage.setItem(IS_SHOWN_REPLENISHMENT_WORKBOOKS, JSON.stringify(this.isShown));
+    }
+  };
+
+  reset() {
+    this.isShown = false;
+  }
+}
+
+export const replenishmentWorkBooksStore = new ReplenishmentWorkBooksStore();

--- a/src/lib/stores/replenishment_workbook.svelte.ts
+++ b/src/lib/stores/replenishment_workbook.svelte.ts
@@ -29,11 +29,11 @@ class ReplenishmentWorkBooksStore {
     }
   }
 
-  canView() {
+  canView(): boolean {
     return this.isShown;
   }
 
-  toggleView() {
+  toggleView(): void {
     this.isShown = !this.isShown;
 
     if (browser) {

--- a/src/lib/stores/replenishment_workbook.svelte.ts
+++ b/src/lib/stores/replenishment_workbook.svelte.ts
@@ -27,13 +27,13 @@ class ReplenishmentWorkBooksStore {
     return this.isShown;
   }
 
-  toggleView = () => {
+  toggleView() {
     this.isShown = !this.isShown;
 
     if (browser) {
       localStorage.setItem(IS_SHOWN_REPLENISHMENT_WORKBOOKS, JSON.stringify(this.isShown));
     }
-  };
+  }
 
   reset() {
     this.isShown = false;

--- a/src/lib/stores/replenishment_workbook.svelte.ts
+++ b/src/lib/stores/replenishment_workbook.svelte.ts
@@ -20,7 +20,13 @@ class ReplenishmentWorkBooksStore {
     }
 
     const savedStatus = localStorage.getItem(IS_SHOWN_REPLENISHMENT_WORKBOOKS);
-    return savedStatus ? JSON.parse(savedStatus) : false;
+
+    try {
+      return savedStatus ? JSON.parse(savedStatus) : false;
+    } catch (error) {
+      console.warn('Failed to parse replenishment workbooks visibility state:', error);
+      return false;
+    }
   }
 
   canView() {

--- a/src/test/lib/stores/replenishment_workbook.test.ts
+++ b/src/test/lib/stores/replenishment_workbook.test.ts
@@ -53,16 +53,20 @@ describe('Replenishment workbooks store', () => {
     expect(mockLocalStorage.setItem).toHaveBeenCalledWith(localStorageKey, JSON.stringify(true));
   });
 
-  test('handles SSR gracefully', () => {
+  test('handles invalid localStorage data', () => {
+    localStorage.setItem(localStorageKey, 'invalid-json');
+    expect(replenishmentWorkBooksStore.canView()).toBeFalsy();
+  });
+});
+
+describe('Replenishment workbooks store in SSR', () => {
+  beforeEach(() => {
     vi.mock('$app/environment', () => ({
       browser: false,
     }));
-
-    expect(replenishmentWorkBooksStore.canView()).toBeFalsy();
   });
 
-  test('handles invalid localStorage data', () => {
-    localStorage.setItem(localStorageKey, 'invalid-json');
+  test('handles SSR gracefully', () => {
     expect(replenishmentWorkBooksStore.canView()).toBeFalsy();
   });
 });

--- a/src/test/lib/stores/replenishment_workbook.test.ts
+++ b/src/test/lib/stores/replenishment_workbook.test.ts
@@ -31,31 +31,16 @@ describe('Replenishment workbooks store', () => {
     expect(replenishmentWorkBooksStore.canView()).toBeFalsy();
   });
 
-  test('expects to be visible after toggling once', () => {
-    replenishmentWorkBooksStore.toggleView();
-    expect(replenishmentWorkBooksStore.canView()).toBeTruthy();
-  });
-
-  test('expects to be invisible after toggling twice', () => {
-    replenishmentWorkBooksStore.toggleView();
-    replenishmentWorkBooksStore.toggleView();
-    expect(replenishmentWorkBooksStore.canView()).toBeFalsy();
-  });
-
-  test('expects to be visible after toggling three times', () => {
-    for (let i = 1; i <= 3; i++) {
+  test.each([
+    { toggles: 1, expected: true },
+    { toggles: 2, expected: false },
+    { toggles: 3, expected: true },
+    { toggles: 4, expected: false },
+  ])('expects to be $expected after toggling $toggles times', ({ toggles, expected }) => {
+    for (let i = 1; i <= toggles; i++) {
       replenishmentWorkBooksStore.toggleView();
     }
-
-    expect(replenishmentWorkBooksStore.canView()).toBeTruthy();
-  });
-
-  test('expects to be invisible after toggling four times', () => {
-    for (let i = 1; i <= 4; i++) {
-      replenishmentWorkBooksStore.toggleView();
-    }
-
-    expect(replenishmentWorkBooksStore.canView()).toBeFalsy();
+    expect(replenishmentWorkBooksStore.canView()).toBe(expected);
   });
 
   // Note: This test is skipped because it is not possible to mock localStorage in JSDOM.

--- a/src/test/lib/stores/replenishment_workbook.test.ts
+++ b/src/test/lib/stores/replenishment_workbook.test.ts
@@ -1,9 +1,25 @@
-import { expect, test } from 'vitest';
+import { expect, test, vi } from 'vitest';
 
 import { replenishmentWorkBooksStore } from '$lib/stores/replenishment_workbook.svelte';
 
+vi.mock('$app/environment', () => ({
+  browser: true,
+}));
+
 describe('Replenishment workbooks store', () => {
+  const localStorageKey = 'is_shown_replenishment_workbooks';
+  const mockLocalStorage = {
+    getItem: vi.fn(),
+    setItem: vi.fn(),
+    removeItem: vi.fn(),
+    clear: vi.fn(),
+  };
+
   beforeEach(() => {
+    vi.clearAllMocks();
+    // Setup mock for localStorage
+    vi.stubGlobal('localStorage', mockLocalStorage);
+
     replenishmentWorkBooksStore.reset();
   });
 
@@ -35,6 +51,29 @@ describe('Replenishment workbooks store', () => {
       replenishmentWorkBooksStore.toggleView();
     }
 
+    expect(replenishmentWorkBooksStore.canView()).toBeFalsy();
+  });
+
+  // Note: This test is skipped because it is not possible to mock localStorage in JSDOM.
+  test.skip('persists state in localStorage', () => {
+    mockLocalStorage.getItem.mockReturnValue(JSON.stringify(false));
+
+    replenishmentWorkBooksStore.toggleView();
+
+    expect(mockLocalStorage.setItem).toHaveBeenCalledTimes(1);
+    expect(mockLocalStorage.setItem).toHaveBeenCalledWith(localStorageKey, JSON.stringify(true));
+  });
+
+  test('handles SSR gracefully', () => {
+    vi.mock('$app/environment', () => ({
+      browser: false,
+    }));
+
+    expect(replenishmentWorkBooksStore.canView()).toBeFalsy();
+  });
+
+  test('handles invalid localStorage data', () => {
+    localStorage.setItem(localStorageKey, 'invalid-json');
     expect(replenishmentWorkBooksStore.canView()).toBeFalsy();
   });
 });

--- a/src/test/lib/stores/replenishment_workbook.test.ts
+++ b/src/test/lib/stores/replenishment_workbook.test.ts
@@ -8,11 +8,13 @@ vi.mock('$app/environment', () => ({
 
 describe('Replenishment workbooks store', () => {
   const localStorageKey = 'is_shown_replenishment_workbooks';
-  const mockLocalStorage = {
+  const mockLocalStorage: Storage = {
     getItem: vi.fn(),
     setItem: vi.fn(),
     removeItem: vi.fn(),
     clear: vi.fn(),
+    length: 0,
+    key: vi.fn(),
   };
 
   beforeEach(() => {
@@ -45,7 +47,7 @@ describe('Replenishment workbooks store', () => {
 
   // Note: This test is skipped because it is not possible to mock localStorage in JSDOM.
   test.skip('persists state in localStorage', () => {
-    mockLocalStorage.getItem.mockReturnValue(JSON.stringify(false));
+    (mockLocalStorage.getItem as jest.Mock).mockReturnValue(JSON.stringify(false));
 
     replenishmentWorkBooksStore.toggleView();
 

--- a/src/test/lib/stores/replenishment_workbook.test.ts
+++ b/src/test/lib/stores/replenishment_workbook.test.ts
@@ -23,6 +23,10 @@ describe('Replenishment workbooks store', () => {
     replenishmentWorkBooksStore.reset();
   });
 
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   test('expects to be invisible before toggling', () => {
     expect(replenishmentWorkBooksStore.canView()).toBeFalsy();
   });

--- a/src/test/lib/stores/replenishment_workbook.test.ts
+++ b/src/test/lib/stores/replenishment_workbook.test.ts
@@ -1,0 +1,40 @@
+import { expect, test } from 'vitest';
+
+import { replenishmentWorkBooksStore } from '$lib/stores/replenishment_workbook.svelte';
+
+describe('Replenishment workbooks store', () => {
+  beforeEach(() => {
+    replenishmentWorkBooksStore.reset();
+  });
+
+  test('expects to be invisible before toggling', () => {
+    expect(replenishmentWorkBooksStore.canView()).toBeFalsy();
+  });
+
+  test('expects to be visible after toggling once', () => {
+    replenishmentWorkBooksStore.toggleView();
+    expect(replenishmentWorkBooksStore.canView()).toBeTruthy();
+  });
+
+  test('expects to be invisible after toggling twice', () => {
+    replenishmentWorkBooksStore.toggleView();
+    replenishmentWorkBooksStore.toggleView();
+    expect(replenishmentWorkBooksStore.canView()).toBeFalsy();
+  });
+
+  test('expects to be visible after toggling three times', () => {
+    for (let i = 1; i <= 3; i++) {
+      replenishmentWorkBooksStore.toggleView();
+    }
+
+    expect(replenishmentWorkBooksStore.canView()).toBeTruthy();
+  });
+
+  test('expects to be invisible after toggling four times', () => {
+    for (let i = 1; i <= 4; i++) {
+      replenishmentWorkBooksStore.toggleView();
+    }
+
+    expect(replenishmentWorkBooksStore.canView()).toBeFalsy();
+  });
+});


### PR DESCRIPTION
close #1726

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the workbook display to ensure the control for viewing replenished workbooks is always visible and updates based on user preferences.
  
- **Tests**
  - Introduced automated tests to validate the toggling functionality of the replenished workbooks store across multiple scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->