### PR TITLE
✨ Add task for digit DP (#2097)

### DIFF
--- a/src/lib/utils/contest.ts
+++ b/src/lib/utils/contest.ts
@@ -165,6 +165,7 @@ const atCoderUniversityPrefixes = getContestPrefixes(ATCODER_UNIVERSITIES);
  */
 const ATCODER_OTHERS: ContestPrefix = {
   chokudai_S: 'Chokudai SpeedRun',
+  'code-festival-2014-quala': 'Code Festival 2014 予選 A',
   'code-festival-2014-qualb': 'Code Festival 2014 予選 B',
   'code-festival-2014-final': 'Code Festival 2014 決勝',
   'code-festival-2015-morning-middle': 'CODE FESTIVAL 2015 あさぷろ Middle',

--- a/src/test/lib/utils/test_cases/contest_type.ts
+++ b/src/test/lib/utils/test_cases/contest_type.ts
@@ -307,6 +307,10 @@ export const atCoderOthers = [
     contestId: 'chokudai_S002',
     expected: ContestType.OTHERS,
   }),
+  createTestCaseForContestType('CODE FESTIVAL 2014 qual A')({
+    contestId: 'code-festival-2014-quala',
+    expected: ContestType.OTHERS,
+  }),
   createTestCaseForContestType('CODE FESTIVAL 2014 qual B')({
     contestId: 'code-festival-2014-qualb',
     expected: ContestType.OTHERS,


### PR DESCRIPTION
close #2097

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for recognizing and displaying "CODE FESTIVAL 2014 qual A" as a contest.
- **Tests**
  - Added a new test case to verify correct handling of "CODE FESTIVAL 2014 qual A" contest type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->