### PR TITLE
💥 Bump eslint-plugin-svelte from 2.46.1 to 3.9.2 (#2197)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -73,6 +73,8 @@ export default [
       // Disable some strict Svelte rules that are too aggressive
       'svelte/require-each-key': 'warn',
       'svelte/no-useless-mustaches': 'warn',
+      'svelte/prefer-writable-derived': 'warn', // New in 3.6.0 - prefer $derived over $state+$effect
+      'svelte/valid-prop-names-in-kit-pages': 'warn', // Allow props other than data/errors in pages
       'no-unused-vars': 'off', // Use TypeScript version instead
       'no-undef': 'off', // TypeScript handles this
     },

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -30,7 +30,10 @@ export default [
       'prisma/.fabbrica/index.ts',
     ],
   },
+  // Base JS rules first
   js.configs.recommended,
+  // Svelte rules override JS rules where appropriate (intentional)
+  // This allows Svelte-specific handling of rules like no-undef, no-unused-vars
   ...sveltePlugin.configs['flat/recommended'],
   {
     plugins: {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -4,19 +4,9 @@
 import typescriptEslint from '@typescript-eslint/eslint-plugin';
 import globals from 'globals';
 import tsParser from '@typescript-eslint/parser';
-import parser from 'svelte-eslint-parser';
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
+import svelteParser from 'svelte-eslint-parser';
+import sveltePlugin from 'eslint-plugin-svelte';
 import js from '@eslint/js';
-import { FlatCompat } from '@eslint/eslintrc';
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const compat = new FlatCompat({
-  baseDirectory: __dirname,
-  recommendedConfig: js.configs.recommended,
-  allConfig: js.configs.all,
-});
 
 export default [
   {
@@ -40,12 +30,8 @@ export default [
       'prisma/.fabbrica/index.ts',
     ],
   },
-  ...compat.extends(
-    'eslint:recommended',
-    'plugin:@typescript-eslint/recommended',
-    'plugin:svelte/recommended',
-    'prettier',
-  ),
+  js.configs.recommended,
+  ...sveltePlugin.configs['flat/recommended'],
   {
     plugins: {
       '@typescript-eslint': typescriptEslint,
@@ -55,6 +41,13 @@ export default [
       globals: {
         ...globals.browser,
         ...globals.node,
+        // Add Svelte 5 runes as global variables
+        $state: 'readonly',
+        $derived: 'readonly',
+        $effect: 'readonly',
+        $props: 'readonly',
+        $bindable: 'readonly',
+        $inspect: 'readonly',
       },
 
       parser: tsParser,
@@ -74,13 +67,21 @@ export default [
           'ts-ignore': false,
         },
       ],
+      // Add TypeScript ESLint rules manually
+      '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+      '@typescript-eslint/no-explicit-any': 'warn',
+      // Disable some strict Svelte rules that are too aggressive
+      'svelte/require-each-key': 'warn',
+      'svelte/no-useless-mustaches': 'warn',
+      'no-unused-vars': 'off', // Use TypeScript version instead
+      'no-undef': 'off', // TypeScript handles this
     },
   },
   {
     files: ['**/*.svelte'],
 
     languageOptions: {
-      parser: parser,
+      parser: svelteParser,
       ecmaVersion: 5,
       sourceType: 'script',
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -84,8 +84,8 @@ export default [
 
     languageOptions: {
       parser: svelteParser,
-      ecmaVersion: 5,
-      sourceType: 'script',
+      ecmaVersion: 'latest', // ES2023+ features support
+      sourceType: 'module', // ESM import/export support
 
       parserOptions: {
         parser: '@typescript-eslint/parser',

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@vitest/ui": "3.2.4",
     "eslint": "9.29.0",
     "eslint-config-prettier": "10.1.5",
-    "eslint-plugin-svelte": "3.0.0",
+    "eslint-plugin-svelte": "3.9.2",
     "globals": "16.2.0",
     "husky": "9.1.7",
     "jsdom": "26.1.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@vitest/ui": "3.2.4",
     "eslint": "9.29.0",
     "eslint-config-prettier": "10.1.5",
-    "eslint-plugin-svelte": "2.46.1",
+    "eslint-plugin-svelte": "3.0.0",
     "globals": "16.2.0",
     "husky": "9.1.7",
     "jsdom": "26.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,8 +127,8 @@ importers:
         specifier: 10.1.5
         version: 10.1.5(eslint@9.29.0(jiti@1.21.6))
       eslint-plugin-svelte:
-        specifier: 3.0.0
-        version: 3.0.0(eslint@9.29.0(jiti@1.21.6))(svelte@5.34.5)(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.6.3))
+        specifier: 3.9.2
+        version: 3.9.2(eslint@9.29.0(jiti@1.21.6))(svelte@5.34.5)(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.6.3))
       globals:
         specifier: 16.2.0
         version: 16.2.0
@@ -2665,21 +2665,15 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
-  eslint-compat-utils@0.6.5:
-    resolution: {integrity: sha512-vAUHYzue4YAa2hNACjB8HvUQj5yehAZgiClyFVVom9cP8z5NSFq3PwB/TtJslN2zAMgRX6FCFCjYBbQh71g5RQ==}
-    engines: {node: '>=12'}
-    peerDependencies:
-      eslint: '>=6.0.0'
-
   eslint-config-prettier@10.1.5:
     resolution: {integrity: sha512-zc1UmCpNltmVY34vuLRV61r1K27sWuX39E+uyUnY8xS2Bex88VV9cugG+UZbRSRGtGyFboj+D8JODyme1plMpw==}
     hasBin: true
     peerDependencies:
       eslint: '>=7.0.0'
 
-  eslint-plugin-svelte@3.0.0:
-    resolution: {integrity: sha512-o+DNY7R8RT95vSBN1DkBJhB1/8M25yCrR3Im9guVToIuW6TB93yqMLXHrRkfKmH9X2cv5tQHvLzO2Vllsz2uTA==}
-    engines: {node: ^18.20.4 || ^20.18.0 || >=22.10.0}
+  eslint-plugin-svelte@3.9.2:
+    resolution: {integrity: sha512-aqzfHtG9RPaFhCUFm5QFC6eFY/yHFQIT8VYYFe7/mT2A9mbgVR3XV2keCqU19LN8iVD9mdvRvqHU+4+CzJImvg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.1 || ^9.0.0
       svelte: ^3.37.0 || ^4.0.0 || ^5.0.0
@@ -3253,8 +3247,8 @@ packages:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
 
-  known-css-properties@0.35.0:
-    resolution: {integrity: sha512-a/RAk2BfKk+WFGhhOCAYqSiFLc34k8Mt/6NWRI4joER0EYUzXIcFivjjnoD3+XU1DggLn/tZc3DOAgke7l8a4A==}
+  known-css-properties@0.36.0:
+    resolution: {integrity: sha512-A+9jP+IUmuQsNdsLdcg6Yt7voiMF/D4K83ew0OpJtpu+l34ef7LaohWV0Rc6KNvzw6ZDizkqfyB5JznZnzuKQA==}
 
   kolorist@1.8.0:
     resolution: {integrity: sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==}
@@ -7440,23 +7434,18 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-compat-utils@0.6.5(eslint@9.29.0(jiti@1.21.6)):
-    dependencies:
-      eslint: 9.29.0(jiti@1.21.6)
-      semver: 7.7.2
-
   eslint-config-prettier@10.1.5(eslint@9.29.0(jiti@1.21.6)):
     dependencies:
       eslint: 9.29.0(jiti@1.21.6)
 
-  eslint-plugin-svelte@3.0.0(eslint@9.29.0(jiti@1.21.6))(svelte@5.34.5)(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.6.3)):
+  eslint-plugin-svelte@3.9.2(eslint@9.29.0(jiti@1.21.6))(svelte@5.34.5)(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.6.3)):
     dependencies:
       '@eslint-community/eslint-utils': 4.7.0(eslint@9.29.0(jiti@1.21.6))
       '@jridgewell/sourcemap-codec': 1.5.0
       eslint: 9.29.0(jiti@1.21.6)
-      eslint-compat-utils: 0.6.5(eslint@9.29.0(jiti@1.21.6))
       esutils: 2.0.3
-      known-css-properties: 0.35.0
+      globals: 16.2.0
+      known-css-properties: 0.36.0
       postcss: 8.5.6
       postcss-load-config: 3.1.4(postcss@8.5.6)(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.6.3))
       postcss-safe-parser: 7.0.1(postcss@8.5.6)
@@ -8062,7 +8051,7 @@ snapshots:
 
   kleur@4.1.5: {}
 
-  known-css-properties@0.35.0: {}
+  known-css-properties@0.36.0: {}
 
   kolorist@1.8.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,8 +127,8 @@ importers:
         specifier: 10.1.5
         version: 10.1.5(eslint@9.29.0(jiti@1.21.6))
       eslint-plugin-svelte:
-        specifier: 2.46.1
-        version: 2.46.1(eslint@9.29.0(jiti@1.21.6))(svelte@5.34.5)(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.6.3))
+        specifier: 3.0.0
+        version: 3.0.0(eslint@9.29.0(jiti@1.21.6))(svelte@5.34.5)(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.6.3))
       globals:
         specifier: 16.2.0
         version: 16.2.0
@@ -773,12 +773,6 @@ packages:
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
-
-  '@eslint-community/eslint-utils@4.4.0':
-    resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
 
   '@eslint-community/eslint-utils@4.7.0':
     resolution: {integrity: sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==}
@@ -2671,8 +2665,8 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
-  eslint-compat-utils@0.5.1:
-    resolution: {integrity: sha512-3z3vFexKIEnjHE3zCMRo6fn/e44U7T1khUjg+Hp0ZQMCigh28rALD0nPFBcGZuiLC5rLZa2ubQHDRln09JfU2Q==}
+  eslint-compat-utils@0.6.5:
+    resolution: {integrity: sha512-vAUHYzue4YAa2hNACjB8HvUQj5yehAZgiClyFVVom9cP8z5NSFq3PwB/TtJslN2zAMgRX6FCFCjYBbQh71g5RQ==}
     engines: {node: '>=12'}
     peerDependencies:
       eslint: '>=6.0.0'
@@ -2683,19 +2677,15 @@ packages:
     peerDependencies:
       eslint: '>=7.0.0'
 
-  eslint-plugin-svelte@2.46.1:
-    resolution: {integrity: sha512-7xYr2o4NID/f9OEYMqxsEQsCsj4KaMy4q5sANaKkAb6/QeCjYFxRmDm2S3YC3A3pl1kyPZ/syOx/i7LcWYSbIw==}
-    engines: {node: ^14.17.0 || >=16.0.0}
+  eslint-plugin-svelte@3.0.0:
+    resolution: {integrity: sha512-o+DNY7R8RT95vSBN1DkBJhB1/8M25yCrR3Im9guVToIuW6TB93yqMLXHrRkfKmH9X2cv5tQHvLzO2Vllsz2uTA==}
+    engines: {node: ^18.20.4 || ^20.18.0 || >=22.10.0}
     peerDependencies:
-      eslint: ^7.0.0 || ^8.0.0-0 || ^9.0.0-0
+      eslint: ^8.57.1 || ^9.0.0
       svelte: ^3.37.0 || ^4.0.0 || ^5.0.0
     peerDependenciesMeta:
       svelte:
         optional: true
-
-  eslint-scope@7.2.2:
-    resolution: {integrity: sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
   eslint-scope@8.3.0:
     resolution: {integrity: sha512-pUNxi75F8MJ/GdeKtVLSbYg4ZI34J6C0C7sbL4YOp2exGwen7ZsuBqKzUhXd0qMQ362yET3z+uPwKeg/0C2XCQ==}
@@ -2740,10 +2730,6 @@ packages:
   espree@10.4.0:
     resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  espree@9.6.1:
-    resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
   esquery@1.6.0:
     resolution: {integrity: sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==}
@@ -3489,11 +3475,6 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  nanoid@3.3.8:
-    resolution: {integrity: sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-
   nanoid@5.0.7:
     resolution: {integrity: sha512-oLxFY2gd2IqnjcYyOXD8XGCftpGtZP2AbHbOkthDkvRywH5ayNtPVy9YlOPcHckXzbLTCHpkb7FB+yuxKV13pQ==}
     engines: {node: ^18 || >=20}
@@ -3784,11 +3765,11 @@ packages:
     peerDependencies:
       postcss: ^8.2.14
 
-  postcss-safe-parser@6.0.0:
-    resolution: {integrity: sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==}
-    engines: {node: '>=12.0'}
+  postcss-safe-parser@7.0.1:
+    resolution: {integrity: sha512-0AioNCJZ2DPYz5ABT6bddIqlhgwhpHZ/l65YAYo0BCIn0xiDpsnTHz0gnoTGk0OXZW0JRs+cDwL8u/teRdz+8A==}
+    engines: {node: '>=18.0'}
     peerDependencies:
-      postcss: ^8.3.3
+      postcss: ^8.4.31
 
   postcss-scss@4.0.9:
     resolution: {integrity: sha512-AjKOeiwAitL/MXxQW2DliT28EKukvvbEWx3LBmJIRN8KfBGZbRTxNYW0kSqi1COiTZ57nZ9NW06S6ux//N1c9A==}
@@ -3813,6 +3794,10 @@ packages:
 
   postcss@8.5.3:
     resolution: {integrity: sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.5.6:
+    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -4117,11 +4102,6 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  semver@7.6.2:
-    resolution: {integrity: sha512-FNAIBWCx9qcRhoHcgcJ0gvU7SN1lYU2ZXuSfl04bSC5OpvDHFyJCjdNHomPXxjQlCBU67YW64PzY7/VIEH7F2w==}
-    engines: {node: '>=10'}
-    hasBin: true
-
   semver@7.7.2:
     resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
     engines: {node: '>=10'}
@@ -4311,15 +4291,6 @@ packages:
     peerDependencies:
       svelte: ^4.0.0 || ^5.0.0-next.0
       typescript: '>=5.0.0'
-
-  svelte-eslint-parser@0.43.0:
-    resolution: {integrity: sha512-GpU52uPKKcVnh8tKN5P4UZpJ/fUDndmq7wfsvoVXsyP+aY0anol7Yqo01fyrlaWGMFfm4av5DyrjlaXdLRJvGA==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      svelte: ^3.37.0 || ^4.0.0 || ^5.0.0
-    peerDependenciesMeta:
-      svelte:
-        optional: true
 
   svelte-eslint-parser@1.2.0:
     resolution: {integrity: sha512-mbPtajIeuiyU80BEyGvwAktBeTX7KCr5/0l+uRGLq1dafwRNrjfM5kHGJScEBlPG3ipu6dJqfW/k0/fujvIEVw==}
@@ -5283,11 +5254,6 @@ snapshots:
 
   '@esbuild/win32-x64@0.25.5':
     optional: true
-
-  '@eslint-community/eslint-utils@4.4.0(eslint@9.29.0(jiti@1.21.6))':
-    dependencies:
-      eslint: 9.29.0(jiti@1.21.6)
-      eslint-visitor-keys: 3.4.3
 
   '@eslint-community/eslint-utils@4.7.0(eslint@9.29.0(jiti@1.21.6))':
     dependencies:
@@ -7474,38 +7440,32 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-compat-utils@0.5.1(eslint@9.29.0(jiti@1.21.6)):
+  eslint-compat-utils@0.6.5(eslint@9.29.0(jiti@1.21.6)):
     dependencies:
       eslint: 9.29.0(jiti@1.21.6)
-      semver: 7.6.2
+      semver: 7.7.2
 
   eslint-config-prettier@10.1.5(eslint@9.29.0(jiti@1.21.6)):
     dependencies:
       eslint: 9.29.0(jiti@1.21.6)
 
-  eslint-plugin-svelte@2.46.1(eslint@9.29.0(jiti@1.21.6))(svelte@5.34.5)(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.6.3)):
+  eslint-plugin-svelte@3.0.0(eslint@9.29.0(jiti@1.21.6))(svelte@5.34.5)(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.6.3)):
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@9.29.0(jiti@1.21.6))
+      '@eslint-community/eslint-utils': 4.7.0(eslint@9.29.0(jiti@1.21.6))
       '@jridgewell/sourcemap-codec': 1.5.0
       eslint: 9.29.0(jiti@1.21.6)
-      eslint-compat-utils: 0.5.1(eslint@9.29.0(jiti@1.21.6))
+      eslint-compat-utils: 0.6.5(eslint@9.29.0(jiti@1.21.6))
       esutils: 2.0.3
       known-css-properties: 0.35.0
-      postcss: 8.4.49
-      postcss-load-config: 3.1.4(postcss@8.4.49)(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.6.3))
-      postcss-safe-parser: 6.0.0(postcss@8.4.49)
-      postcss-selector-parser: 6.1.2
-      semver: 7.6.2
-      svelte-eslint-parser: 0.43.0(svelte@5.34.5)
+      postcss: 8.5.6
+      postcss-load-config: 3.1.4(postcss@8.5.6)(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.6.3))
+      postcss-safe-parser: 7.0.1(postcss@8.5.6)
+      semver: 7.7.2
+      svelte-eslint-parser: 1.2.0(svelte@5.34.5)
     optionalDependencies:
       svelte: 5.34.5
     transitivePeerDependencies:
       - ts-node
-
-  eslint-scope@7.2.2:
-    dependencies:
-      esrecurse: 4.3.0
-      estraverse: 5.3.0
 
   eslint-scope@8.3.0:
     dependencies:
@@ -7580,12 +7540,6 @@ snapshots:
       acorn: 8.15.0
       acorn-jsx: 5.3.2(acorn@8.15.0)
       eslint-visitor-keys: 4.2.1
-
-  espree@9.6.1:
-    dependencies:
-      acorn: 8.15.0
-      acorn-jsx: 5.3.2(acorn@8.15.0)
-      eslint-visitor-keys: 3.4.3
 
   esquery@1.6.0:
     dependencies:
@@ -8332,8 +8286,6 @@ snapshots:
 
   nanoid@3.3.11: {}
 
-  nanoid@3.3.8: {}
-
   nanoid@5.0.7: {}
 
   natural-compare@1.4.0: {}
@@ -8552,12 +8504,12 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.4.49
 
-  postcss-load-config@3.1.4(postcss@8.4.49)(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.6.3)):
+  postcss-load-config@3.1.4(postcss@8.5.6)(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.6.3)):
     dependencies:
       lilconfig: 2.1.0
       yaml: 1.10.2
     optionalDependencies:
-      postcss: 8.4.49
+      postcss: 8.5.6
       ts-node: 10.9.1(@types/node@24.0.3)(typescript@5.6.3)
 
   postcss-load-config@4.0.2(postcss@8.4.49)(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.6.3)):
@@ -8573,13 +8525,9 @@ snapshots:
       postcss: 8.4.49
       postcss-selector-parser: 6.1.2
 
-  postcss-safe-parser@6.0.0(postcss@8.4.49):
+  postcss-safe-parser@7.0.1(postcss@8.5.6):
     dependencies:
-      postcss: 8.4.49
-
-  postcss-scss@4.0.9(postcss@8.4.49):
-    dependencies:
-      postcss: 8.4.49
+      postcss: 8.5.6
 
   postcss-scss@4.0.9(postcss@8.5.3):
     dependencies:
@@ -8599,11 +8547,17 @@ snapshots:
 
   postcss@8.4.49:
     dependencies:
-      nanoid: 3.3.8
+      nanoid: 3.3.11
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
   postcss@8.5.3:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.6:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -8879,8 +8833,6 @@ snapshots:
     dependencies:
       lru-cache: 6.0.0
 
-  semver@7.6.2: {}
-
   semver@7.7.2: {}
 
   set-cookie-parser@2.7.1: {}
@@ -9078,16 +9030,6 @@ snapshots:
       typescript: 5.6.3
     transitivePeerDependencies:
       - picomatch
-
-  svelte-eslint-parser@0.43.0(svelte@5.34.5):
-    dependencies:
-      eslint-scope: 7.2.2
-      eslint-visitor-keys: 3.4.3
-      espree: 9.6.1
-      postcss: 8.4.49
-      postcss-scss: 4.0.9(postcss@8.4.49)
-    optionalDependencies:
-      svelte: 5.34.5
 
   svelte-eslint-parser@1.2.0(svelte@5.34.5):
     dependencies:

--- a/src/lib/components/GradeLabel.svelte
+++ b/src/lib/components/GradeLabel.svelte
@@ -46,7 +46,7 @@
     {#if taskGrade !== TaskGrade.PENDING}
       {grade}
     {:else}
-      {'−'}
+      −
     {/if}
   </div>
 </div>

--- a/src/lib/components/SubmissionStatus/IconForUpdating.svelte
+++ b/src/lib/components/SubmissionStatus/IconForUpdating.svelte
@@ -12,9 +12,7 @@
 <!-- src/lib/components/SubmissionStatus/SubmissionStatusImage.svelte -->
 {#if isLoggedIn}
   <div class="flex items-center justify-center text-sm space-x-1">
-    <div class="dark:text-gray-300">
-      更新
-    </div>
+    <div class="dark:text-gray-300">更新</div>
 
     <div class="text-primary-600 dark:text-gray-300 inline">
       <ChevronDown size="16" />

--- a/src/lib/components/SubmissionStatus/IconForUpdating.svelte
+++ b/src/lib/components/SubmissionStatus/IconForUpdating.svelte
@@ -13,7 +13,7 @@
 {#if isLoggedIn}
   <div class="flex items-center justify-center text-sm space-x-1">
     <div class="dark:text-gray-300">
-      {'更新'}
+      更新
     </div>
 
     <div class="text-primary-600 dark:text-gray-300 inline">

--- a/src/lib/components/SubmissionStatus/SubmissionStatusImage.svelte
+++ b/src/lib/components/SubmissionStatus/SubmissionStatusImage.svelte
@@ -28,7 +28,7 @@
 {#if isLoggedIn}
   <div class="flex flex-col items-center ml-2 md:ml-4 text-xs">
     <div class="pb-1 dark:text-gray-300">
-      {'更新'}
+      更新
     </div>
     <ChevronDown class="w-3 h-3 text-primary-600 dark:text-white inline" />
   </div>

--- a/src/lib/components/SubmissionStatus/SubmissionStatusImage.svelte
+++ b/src/lib/components/SubmissionStatus/SubmissionStatusImage.svelte
@@ -27,9 +27,7 @@
 <!-- TODO: Redirect to login screen when user is not logged in -->
 {#if isLoggedIn}
   <div class="flex flex-col items-center ml-2 md:ml-4 text-xs">
-    <div class="pb-1 dark:text-gray-300">
-      更新
-    </div>
+    <div class="pb-1 dark:text-gray-300">更新</div>
     <ChevronDown class="w-3 h-3 text-primary-600 dark:text-white inline" />
   </div>
 {/if}

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -21,8 +21,6 @@
   {/if}
 
   <div class="flex justify-center mt-6">
-    <Button href={HOME_PAGE} color="primary" class="px-6">
-      ホームに戻る
-    </Button>
+    <Button href={HOME_PAGE} color="primary" class="px-6">ホームに戻る</Button>
   </div>
 </div>

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -22,7 +22,7 @@
 
   <div class="flex justify-center mt-6">
     <Button href={HOME_PAGE} color="primary" class="px-6">
-      {'ホームに戻る'}
+      ホームに戻る
     </Button>
   </div>
 </div>

--- a/src/routes/workbooks/[slug]/+page.svelte
+++ b/src/routes/workbooks/[slug]/+page.svelte
@@ -76,7 +76,6 @@
   };
 
   // HACK:: `updatingModal` is updated, but is not declared with `$state(...)`. Changing its value will not correctly trigger updates.
-   
   let updatingModal: UpdatingModal | null = null;
 
   // HACK: clickを1回実行するとactionsが2回実行されてしまう。原因と修正方法が分かっていない。

--- a/src/routes/workbooks/[slug]/+page.svelte
+++ b/src/routes/workbooks/[slug]/+page.svelte
@@ -76,7 +76,7 @@
   };
 
   // HACK:: `updatingModal` is updated, but is not declared with `$state(...)`. Changing its value will not correctly trigger updates.
-  // eslint-disable-next-line svelte/valid-compile
+   
   let updatingModal: UpdatingModal | null = null;
 
   // HACK: clickを1回実行するとactionsが2回実行されてしまう。原因と修正方法が分かっていない。
@@ -222,6 +222,6 @@
 
     <UpdatingModal bind:this={updatingModal} {isLoggedIn} />
   {:else}
-    {'問題を1問以上登録してください。'}
+    問題を1問以上登録してください。
   {/if}
 </div>

--- a/src/routes/workbooks/create/+page.svelte
+++ b/src/routes/workbooks/create/+page.svelte
@@ -28,7 +28,7 @@
 
 <WorkBookForm
   pageTitle="問題集を作成"
-  breadcrumbTitle={'問題集を作成'}
+  breadcrumbTitle="問題集を作成"
   isAdmin={data.isAdmin}
   {superFormObject}
   {tasksMapByIds}


### PR DESCRIPTION
close #2197

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Modernized ESLint configuration to use the latest flat config format, updated Svelte parser and plugin imports, and added Svelte 5 global variables.
  - Updated TypeScript and Svelte linting rules for improved clarity and consistency.
  - Upgraded the eslint-plugin-svelte package to the latest version.

- **Style**
  - Simplified template syntax in several components by using direct text nodes instead of expressions wrapped in braces.
  - Removed unnecessary ESLint comments and cleaned up minor code formatting in Svelte files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->