### PR TITLE
💥 Bump typescript from 5.6.3 to 5.8.3 (#2199)

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "svelte-meta-tags": "4.4.0",
     "sveltekit-superforms": "2.27.0",
     "tslib": "2.8.1",
-    "typescript": "5.6.3",
+    "typescript": "5.8.3",
     "vite": "6.3.5",
     "vitest": "3.2.4",
     "zod": "3.25.67"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
         version: 3.0.2(@prisma/client@5.22.0(prisma@5.22.0))(lucia@2.7.7)
       '@mermaid-js/mermaid-cli':
         specifier: 11.4.3
-        version: 11.4.3(puppeteer@19.11.1(typescript@5.6.3))(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.6.3))
+        version: 11.4.3(puppeteer@19.11.1(typescript@5.8.3))(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.8.3))
       '@popperjs/core':
         specifier: 2.11.8
         version: 2.11.8
@@ -61,7 +61,7 @@ importers:
         version: 10.12.1
       prisma-erd-generator:
         specifier: 2.0.4
-        version: 2.0.4(@prisma/client@5.22.0(prisma@5.22.0))(puppeteer@19.11.1(typescript@5.6.3))(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.6.3))
+        version: 2.0.4(@prisma/client@5.22.0(prisma@5.22.0))(puppeteer@19.11.1(typescript@5.8.3))(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.8.3))
       svelte-eslint-parser:
         specifier: 1.2.0
         version: 1.2.0(svelte@5.34.5)
@@ -70,7 +70,7 @@ importers:
         version: 2.6.0
       tailwindcss:
         specifier: 3.4.17
-        version: 3.4.17(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.6.3))
+        version: 3.4.17(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.8.3))
       vercel:
         specifier: 43.2.0
         version: 43.2.0(rollup@4.40.1)
@@ -89,7 +89,7 @@ importers:
         version: 1.53.0
       '@quramy/prisma-fabbrica':
         specifier: 2.3.0
-        version: 2.3.0(@prisma/client@5.22.0(prisma@5.22.0))(typescript@5.6.3)
+        version: 2.3.0(@prisma/client@5.22.0(prisma@5.22.0))(typescript@5.8.3)
       '@sveltejs/adapter-vercel':
         specifier: 5.7.2
         version: 5.7.2(@sveltejs/kit@2.21.5(@sveltejs/vite-plugin-svelte@5.1.0(svelte@5.34.5)(vite@6.3.5(@types/node@24.0.3)(jiti@1.21.6)(yaml@2.8.0)))(svelte@5.34.5)(vite@6.3.5(@types/node@24.0.3)(jiti@1.21.6)(yaml@2.8.0)))(rollup@4.40.1)
@@ -101,7 +101,7 @@ importers:
         version: 5.1.0(svelte@5.34.5)(vite@6.3.5(@types/node@24.0.3)(jiti@1.21.6)(yaml@2.8.0))
       '@tailwindcss/forms':
         specifier: 0.5.10
-        version: 0.5.10(tailwindcss@3.4.17(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.6.3)))
+        version: 0.5.10(tailwindcss@3.4.17(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.8.3)))
       '@testing-library/jest-dom':
         specifier: 6.6.3
         version: 6.6.3
@@ -110,10 +110,10 @@ importers:
         version: 0.0.20
       '@typescript-eslint/eslint-plugin':
         specifier: 8.34.1
-        version: 8.34.1(@typescript-eslint/parser@8.34.1(eslint@9.29.0(jiti@1.21.6))(typescript@5.6.3))(eslint@9.29.0(jiti@1.21.6))(typescript@5.6.3)
+        version: 8.34.1(@typescript-eslint/parser@8.34.1(eslint@9.29.0(jiti@1.21.6))(typescript@5.8.3))(eslint@9.29.0(jiti@1.21.6))(typescript@5.8.3)
       '@typescript-eslint/parser':
         specifier: 8.34.1
-        version: 8.34.1(eslint@9.29.0(jiti@1.21.6))(typescript@5.6.3)
+        version: 8.34.1(eslint@9.29.0(jiti@1.21.6))(typescript@5.8.3)
       '@vitest/coverage-v8':
         specifier: 3.2.4
         version: 3.2.4(vitest@3.2.4)
@@ -128,7 +128,7 @@ importers:
         version: 10.1.5(eslint@9.29.0(jiti@1.21.6))
       eslint-plugin-svelte:
         specifier: 3.9.2
-        version: 3.9.2(eslint@9.29.0(jiti@1.21.6))(svelte@5.34.5)(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.6.3))
+        version: 3.9.2(eslint@9.29.0(jiti@1.21.6))(svelte@5.34.5)(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.8.3))
       globals:
         specifier: 16.2.0
         version: 16.2.0
@@ -167,22 +167,22 @@ importers:
         version: 5.34.5
       svelte-5-ui-lib:
         specifier: 0.12.2
-        version: 0.12.2(svelte@5.34.5)(tailwindcss@3.4.17(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.6.3)))
+        version: 0.12.2(svelte@5.34.5)(tailwindcss@3.4.17(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.8.3)))
       svelte-check:
         specifier: 4.2.1
-        version: 4.2.1(picomatch@4.0.2)(svelte@5.34.5)(typescript@5.6.3)
+        version: 4.2.1(picomatch@4.0.2)(svelte@5.34.5)(typescript@5.8.3)
       svelte-meta-tags:
         specifier: 4.4.0
         version: 4.4.0(svelte@5.34.5)
       sveltekit-superforms:
         specifier: 2.27.0
-        version: 2.27.0(@sveltejs/kit@2.21.5(@sveltejs/vite-plugin-svelte@5.1.0(svelte@5.34.5)(vite@6.3.5(@types/node@24.0.3)(jiti@1.21.6)(yaml@2.8.0)))(svelte@5.34.5)(vite@6.3.5(@types/node@24.0.3)(jiti@1.21.6)(yaml@2.8.0)))(@types/json-schema@7.0.15)(esbuild@0.25.5)(svelte@5.34.5)(typescript@5.6.3)
+        version: 2.27.0(@sveltejs/kit@2.21.5(@sveltejs/vite-plugin-svelte@5.1.0(svelte@5.34.5)(vite@6.3.5(@types/node@24.0.3)(jiti@1.21.6)(yaml@2.8.0)))(svelte@5.34.5)(vite@6.3.5(@types/node@24.0.3)(jiti@1.21.6)(yaml@2.8.0)))(@types/json-schema@7.0.15)(esbuild@0.25.5)(svelte@5.34.5)(typescript@5.8.3)
       tslib:
         specifier: 2.8.1
         version: 2.8.1
       typescript:
-        specifier: 5.6.3
-        version: 5.6.3
+        specifier: 5.8.3
+        version: 5.8.3
       vite:
         specifier: 6.3.5
         version: 6.3.5(@types/node@24.0.3)(jiti@1.21.6)(yaml@2.8.0)
@@ -4547,8 +4547,8 @@ packages:
     engines: {node: '>=4.2.0'}
     hasBin: true
 
-  typescript@5.6.3:
-    resolution: {integrity: sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==}
+  typescript@5.8.3:
+    resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -5353,9 +5353,9 @@ snapshots:
 
   '@floating-ui/utils@0.2.9': {}
 
-  '@gcornut/valibot-json-schema@0.42.0(esbuild@0.25.5)(typescript@5.6.3)':
+  '@gcornut/valibot-json-schema@0.42.0(esbuild@0.25.5)(typescript@5.8.3)':
     dependencies:
-      valibot: 0.42.1(typescript@5.6.3)
+      valibot: 0.42.1(typescript@5.8.3)
     optionalDependencies:
       '@types/json-schema': 7.0.15
       esbuild-runner: 2.2.2(esbuild@0.25.5)
@@ -5382,9 +5382,9 @@ snapshots:
       react-dom: 19.1.0(react@19.1.0)
       use-sync-external-store: 1.5.0(react@19.1.0)
 
-  '@headlessui/tailwindcss@0.2.2(tailwindcss@3.4.17(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.6.3)))':
+  '@headlessui/tailwindcss@0.2.2(tailwindcss@3.4.17(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.8.3)))':
     dependencies:
-      tailwindcss: 3.4.17(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.6.3))
+      tailwindcss: 3.4.17(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.8.3))
 
   '@humanfs/core@0.19.1': {}
 
@@ -5496,22 +5496,22 @@ snapshots:
       - encoding
       - supports-color
 
-  '@mermaid-js/mermaid-cli@11.4.3(puppeteer@19.11.1(typescript@5.6.3))(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.6.3))':
+  '@mermaid-js/mermaid-cli@11.4.3(puppeteer@19.11.1(typescript@5.8.3))(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.8.3))':
     dependencies:
-      '@mermaid-js/mermaid-zenuml': 0.2.0(mermaid@11.6.0)(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.6.3))
+      '@mermaid-js/mermaid-zenuml': 0.2.0(mermaid@11.6.0)(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.8.3))
       chalk: 5.4.1
       commander: 13.1.0
       import-meta-resolve: 4.1.0
       mermaid: 11.6.0
-      puppeteer: 19.11.1(typescript@5.6.3)
+      puppeteer: 19.11.1(typescript@5.8.3)
     transitivePeerDependencies:
       - '@types/react'
       - supports-color
       - ts-node
 
-  '@mermaid-js/mermaid-zenuml@0.2.0(mermaid@11.6.0)(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.6.3))':
+  '@mermaid-js/mermaid-zenuml@0.2.0(mermaid@11.6.0)(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.8.3))':
     dependencies:
-      '@zenuml/core': 3.32.3(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.6.3))
+      '@zenuml/core': 3.32.3(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.8.3))
       mermaid: 11.6.0
     transitivePeerDependencies:
       - '@types/react'
@@ -5638,7 +5638,7 @@ snapshots:
     dependencies:
       '@prisma/debug': 6.7.0
 
-  '@prisma/internals@6.7.0(typescript@5.6.3)':
+  '@prisma/internals@6.7.0(typescript@5.8.3)':
     dependencies:
       '@prisma/config': 6.7.0
       '@prisma/debug': 6.7.0
@@ -5655,7 +5655,7 @@ snapshots:
       arg: 5.0.2
       prompts: 2.4.2
     optionalDependencies:
-      typescript: 5.6.3
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
@@ -5668,7 +5668,7 @@ snapshots:
       '@prisma/prisma-schema-wasm': 6.7.0-36.3cff47a7f5d65c3ea74883f1d736e41d68ce91ed
       fs-extra: 11.3.0
 
-  '@puppeteer/browsers@0.5.0(typescript@5.6.3)':
+  '@puppeteer/browsers@0.5.0(typescript@5.8.3)':
     dependencies:
       debug: 4.3.4
       extract-zip: 2.0.1
@@ -5679,18 +5679,18 @@ snapshots:
       unbzip2-stream: 1.4.3
       yargs: 17.7.1
     optionalDependencies:
-      typescript: 5.6.3
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
-  '@quramy/prisma-fabbrica@2.3.0(@prisma/client@5.22.0(prisma@5.22.0))(typescript@5.6.3)':
+  '@quramy/prisma-fabbrica@2.3.0(@prisma/client@5.22.0(prisma@5.22.0))(typescript@5.8.3)':
     dependencies:
       '@prisma/client': 5.22.0(prisma@5.22.0)
       '@prisma/generator-helper': 6.7.0
-      '@prisma/internals': 6.7.0(typescript@5.6.3)
+      '@prisma/internals': 6.7.0(typescript@5.8.3)
       short-uuid: 5.2.0
-      talt: 2.4.4(typescript@5.6.3)
-      typescript: 5.6.3
+      talt: 2.4.4(typescript@5.8.3)
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
@@ -5899,10 +5899,10 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@tailwindcss/forms@0.5.10(tailwindcss@3.4.17(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.6.3)))':
+  '@tailwindcss/forms@0.5.10(tailwindcss@3.4.17(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.8.3)))':
     dependencies:
       mini-svg-data-uri: 1.4.4
-      tailwindcss: 3.4.17(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.6.3))
+      tailwindcss: 3.4.17(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.8.3))
 
   '@tanstack/react-virtual@3.13.10(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
@@ -6151,41 +6151,41 @@ snapshots:
       '@types/json-schema': 7.0.15
     optional: true
 
-  '@typescript-eslint/eslint-plugin@8.34.1(@typescript-eslint/parser@8.34.1(eslint@9.29.0(jiti@1.21.6))(typescript@5.6.3))(eslint@9.29.0(jiti@1.21.6))(typescript@5.6.3)':
+  '@typescript-eslint/eslint-plugin@8.34.1(@typescript-eslint/parser@8.34.1(eslint@9.29.0(jiti@1.21.6))(typescript@5.8.3))(eslint@9.29.0(jiti@1.21.6))(typescript@5.8.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.34.1(eslint@9.29.0(jiti@1.21.6))(typescript@5.6.3)
+      '@typescript-eslint/parser': 8.34.1(eslint@9.29.0(jiti@1.21.6))(typescript@5.8.3)
       '@typescript-eslint/scope-manager': 8.34.1
-      '@typescript-eslint/type-utils': 8.34.1(eslint@9.29.0(jiti@1.21.6))(typescript@5.6.3)
-      '@typescript-eslint/utils': 8.34.1(eslint@9.29.0(jiti@1.21.6))(typescript@5.6.3)
+      '@typescript-eslint/type-utils': 8.34.1(eslint@9.29.0(jiti@1.21.6))(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.34.1(eslint@9.29.0(jiti@1.21.6))(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 8.34.1
       eslint: 9.29.0(jiti@1.21.6)
       graphemer: 1.4.0
       ignore: 7.0.5
       natural-compare: 1.4.0
-      ts-api-utils: 2.1.0(typescript@5.6.3)
-      typescript: 5.6.3
+      ts-api-utils: 2.1.0(typescript@5.8.3)
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.34.1(eslint@9.29.0(jiti@1.21.6))(typescript@5.6.3)':
+  '@typescript-eslint/parser@8.34.1(eslint@9.29.0(jiti@1.21.6))(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.34.1
       '@typescript-eslint/types': 8.34.1
-      '@typescript-eslint/typescript-estree': 8.34.1(typescript@5.6.3)
+      '@typescript-eslint/typescript-estree': 8.34.1(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 8.34.1
       debug: 4.4.1
       eslint: 9.29.0(jiti@1.21.6)
-      typescript: 5.6.3
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.34.1(typescript@5.6.3)':
+  '@typescript-eslint/project-service@8.34.1(typescript@5.8.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.34.1(typescript@5.6.3)
+      '@typescript-eslint/tsconfig-utils': 8.34.1(typescript@5.8.3)
       '@typescript-eslint/types': 8.34.1
       debug: 4.4.1
-      typescript: 5.6.3
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
@@ -6194,27 +6194,27 @@ snapshots:
       '@typescript-eslint/types': 8.34.1
       '@typescript-eslint/visitor-keys': 8.34.1
 
-  '@typescript-eslint/tsconfig-utils@8.34.1(typescript@5.6.3)':
+  '@typescript-eslint/tsconfig-utils@8.34.1(typescript@5.8.3)':
     dependencies:
-      typescript: 5.6.3
+      typescript: 5.8.3
 
-  '@typescript-eslint/type-utils@8.34.1(eslint@9.29.0(jiti@1.21.6))(typescript@5.6.3)':
+  '@typescript-eslint/type-utils@8.34.1(eslint@9.29.0(jiti@1.21.6))(typescript@5.8.3)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 8.34.1(typescript@5.6.3)
-      '@typescript-eslint/utils': 8.34.1(eslint@9.29.0(jiti@1.21.6))(typescript@5.6.3)
+      '@typescript-eslint/typescript-estree': 8.34.1(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.34.1(eslint@9.29.0(jiti@1.21.6))(typescript@5.8.3)
       debug: 4.4.1
       eslint: 9.29.0(jiti@1.21.6)
-      ts-api-utils: 2.1.0(typescript@5.6.3)
-      typescript: 5.6.3
+      ts-api-utils: 2.1.0(typescript@5.8.3)
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
   '@typescript-eslint/types@8.34.1': {}
 
-  '@typescript-eslint/typescript-estree@8.34.1(typescript@5.6.3)':
+  '@typescript-eslint/typescript-estree@8.34.1(typescript@5.8.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.34.1(typescript@5.6.3)
-      '@typescript-eslint/tsconfig-utils': 8.34.1(typescript@5.6.3)
+      '@typescript-eslint/project-service': 8.34.1(typescript@5.8.3)
+      '@typescript-eslint/tsconfig-utils': 8.34.1(typescript@5.8.3)
       '@typescript-eslint/types': 8.34.1
       '@typescript-eslint/visitor-keys': 8.34.1
       debug: 4.4.1
@@ -6222,19 +6222,19 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.5
       semver: 7.7.2
-      ts-api-utils: 2.1.0(typescript@5.6.3)
-      typescript: 5.6.3
+      ts-api-utils: 2.1.0(typescript@5.8.3)
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.34.1(eslint@9.29.0(jiti@1.21.6))(typescript@5.6.3)':
+  '@typescript-eslint/utils@8.34.1(eslint@9.29.0(jiti@1.21.6))(typescript@5.8.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.7.0(eslint@9.29.0(jiti@1.21.6))
       '@typescript-eslint/scope-manager': 8.34.1
       '@typescript-eslint/types': 8.34.1
-      '@typescript-eslint/typescript-estree': 8.34.1(typescript@5.6.3)
+      '@typescript-eslint/typescript-estree': 8.34.1(typescript@5.8.3)
       eslint: 9.29.0(jiti@1.21.6)
-      typescript: 5.6.3
+      typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
 
@@ -6485,11 +6485,11 @@ snapshots:
 
   '@yr/monotone-cubic-spline@1.0.3': {}
 
-  '@zenuml/core@3.32.3(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.6.3))':
+  '@zenuml/core@3.32.3(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.8.3))':
     dependencies:
       '@floating-ui/react': 0.27.12(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@headlessui/react': 2.2.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@headlessui/tailwindcss': 0.2.2(tailwindcss@3.4.17(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.6.3)))
+      '@headlessui/tailwindcss': 0.2.2(tailwindcss@3.4.17(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.8.3)))
       antlr4: 4.11.0
       class-variance-authority: 0.7.1
       clsx: 2.1.1
@@ -6506,7 +6506,7 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
       tailwind-merge: 3.3.1
-      tailwindcss: 3.4.17(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.6.3))
+      tailwindcss: 3.4.17(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.8.3))
     transitivePeerDependencies:
       - '@types/react'
       - ts-node
@@ -7438,7 +7438,7 @@ snapshots:
     dependencies:
       eslint: 9.29.0(jiti@1.21.6)
 
-  eslint-plugin-svelte@3.9.2(eslint@9.29.0(jiti@1.21.6))(svelte@5.34.5)(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.6.3)):
+  eslint-plugin-svelte@3.9.2(eslint@9.29.0(jiti@1.21.6))(svelte@5.34.5)(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.8.3)):
     dependencies:
       '@eslint-community/eslint-utils': 4.7.0(eslint@9.29.0(jiti@1.21.6))
       '@jridgewell/sourcemap-codec': 1.5.0
@@ -7447,7 +7447,7 @@ snapshots:
       globals: 16.2.0
       known-css-properties: 0.36.0
       postcss: 8.5.6
-      postcss-load-config: 3.1.4(postcss@8.5.6)(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.6.3))
+      postcss-load-config: 3.1.4(postcss@8.5.6)(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.8.3))
       postcss-safe-parser: 7.0.1(postcss@8.5.6)
       semver: 7.7.2
       svelte-eslint-parser: 1.2.0(svelte@5.34.5)
@@ -8493,21 +8493,21 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.4.49
 
-  postcss-load-config@3.1.4(postcss@8.5.6)(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.6.3)):
+  postcss-load-config@3.1.4(postcss@8.5.6)(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.8.3)):
     dependencies:
       lilconfig: 2.1.0
       yaml: 1.10.2
     optionalDependencies:
       postcss: 8.5.6
-      ts-node: 10.9.1(@types/node@24.0.3)(typescript@5.6.3)
+      ts-node: 10.9.1(@types/node@24.0.3)(typescript@5.8.3)
 
-  postcss-load-config@4.0.2(postcss@8.4.49)(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.6.3)):
+  postcss-load-config@4.0.2(postcss@8.4.49)(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.8.3)):
     dependencies:
       lilconfig: 3.1.3
       yaml: 2.8.0
     optionalDependencies:
       postcss: 8.4.49
-      ts-node: 10.9.1(@types/node@24.0.3)(typescript@5.6.3)
+      ts-node: 10.9.1(@types/node@24.0.3)(typescript@5.8.3)
 
   postcss-nested@6.2.0(postcss@8.4.49):
     dependencies:
@@ -8583,9 +8583,9 @@ snapshots:
     dependencies:
       parse-ms: 2.1.0
 
-  prisma-erd-generator@2.0.4(@prisma/client@5.22.0(prisma@5.22.0))(puppeteer@19.11.1(typescript@5.6.3))(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.6.3)):
+  prisma-erd-generator@2.0.4(@prisma/client@5.22.0(prisma@5.22.0))(puppeteer@19.11.1(typescript@5.8.3))(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.8.3)):
     dependencies:
-      '@mermaid-js/mermaid-cli': 11.4.3(puppeteer@19.11.1(typescript@5.6.3))(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.6.3))
+      '@mermaid-js/mermaid-cli': 11.4.3(puppeteer@19.11.1(typescript@5.8.3))(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.8.3))
       '@prisma/client': 5.22.0(prisma@5.22.0)
       '@prisma/generator-helper': 6.3.0
       dotenv: 16.4.7
@@ -8628,9 +8628,9 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  puppeteer-core@19.11.1(typescript@5.6.3):
+  puppeteer-core@19.11.1(typescript@5.8.3):
     dependencies:
-      '@puppeteer/browsers': 0.5.0(typescript@5.6.3)
+      '@puppeteer/browsers': 0.5.0(typescript@5.8.3)
       chromium-bidi: 0.4.7(devtools-protocol@0.0.1107588)
       cross-fetch: 3.1.5
       debug: 4.3.4
@@ -8642,21 +8642,21 @@ snapshots:
       unbzip2-stream: 1.4.3
       ws: 8.13.0
     optionalDependencies:
-      typescript: 5.6.3
+      typescript: 5.8.3
     transitivePeerDependencies:
       - bufferutil
       - encoding
       - supports-color
       - utf-8-validate
 
-  puppeteer@19.11.1(typescript@5.6.3):
+  puppeteer@19.11.1(typescript@5.8.3):
     dependencies:
-      '@puppeteer/browsers': 0.5.0(typescript@5.6.3)
+      '@puppeteer/browsers': 0.5.0(typescript@5.8.3)
       cosmiconfig: 8.1.3
       https-proxy-agent: 5.0.1
       progress: 2.0.3
       proxy-from-env: 1.1.0
-      puppeteer-core: 19.11.1(typescript@5.6.3)
+      puppeteer-core: 19.11.1(typescript@5.8.3)
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -8998,17 +8998,17 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svelte-5-ui-lib@0.12.2(svelte@5.34.5)(tailwindcss@3.4.17(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.6.3))):
+  svelte-5-ui-lib@0.12.2(svelte@5.34.5)(tailwindcss@3.4.17(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.8.3))):
     dependencies:
       '@floating-ui/dom': 1.6.13
       apexcharts: 3.54.1
       clsx: 2.1.1
       svelte: 5.34.5
       tailwind-merge: 2.6.0
-      tailwind-variants: 0.3.1(tailwindcss@3.4.17(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.6.3)))
-      tailwindcss: 3.4.17(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.6.3))
+      tailwind-variants: 0.3.1(tailwindcss@3.4.17(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.8.3)))
+      tailwindcss: 3.4.17(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.8.3))
 
-  svelte-check@4.2.1(picomatch@4.0.2)(svelte@5.34.5)(typescript@5.6.3):
+  svelte-check@4.2.1(picomatch@4.0.2)(svelte@5.34.5)(typescript@5.8.3):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
       chokidar: 4.0.3
@@ -9016,7 +9016,7 @@ snapshots:
       picocolors: 1.1.1
       sade: 1.8.1
       svelte: 5.34.5
-      typescript: 5.6.3
+      typescript: 5.8.3
     transitivePeerDependencies:
       - picomatch
 
@@ -9053,7 +9053,7 @@ snapshots:
       magic-string: 0.30.17
       zimmerframe: 1.1.2
 
-  sveltekit-superforms@2.27.0(@sveltejs/kit@2.21.5(@sveltejs/vite-plugin-svelte@5.1.0(svelte@5.34.5)(vite@6.3.5(@types/node@24.0.3)(jiti@1.21.6)(yaml@2.8.0)))(svelte@5.34.5)(vite@6.3.5(@types/node@24.0.3)(jiti@1.21.6)(yaml@2.8.0)))(@types/json-schema@7.0.15)(esbuild@0.25.5)(svelte@5.34.5)(typescript@5.6.3):
+  sveltekit-superforms@2.27.0(@sveltejs/kit@2.21.5(@sveltejs/vite-plugin-svelte@5.1.0(svelte@5.34.5)(vite@6.3.5(@types/node@24.0.3)(jiti@1.21.6)(yaml@2.8.0)))(svelte@5.34.5)(vite@6.3.5(@types/node@24.0.3)(jiti@1.21.6)(yaml@2.8.0)))(@types/json-schema@7.0.15)(esbuild@0.25.5)(svelte@5.34.5)(typescript@5.8.3):
     dependencies:
       '@sveltejs/kit': 2.21.5(@sveltejs/vite-plugin-svelte@5.1.0(svelte@5.34.5)(vite@6.3.5(@types/node@24.0.3)(jiti@1.21.6)(yaml@2.8.0)))(svelte@5.34.5)(vite@6.3.5(@types/node@24.0.3)(jiti@1.21.6)(yaml@2.8.0))
       devalue: 5.1.1
@@ -9062,7 +9062,7 @@ snapshots:
       ts-deepmerge: 7.0.3
     optionalDependencies:
       '@exodus/schemasafe': 1.3.0
-      '@gcornut/valibot-json-schema': 0.42.0(esbuild@0.25.5)(typescript@5.6.3)
+      '@gcornut/valibot-json-schema': 0.42.0(esbuild@0.25.5)(typescript@5.8.3)
       '@sinclair/typebox': 0.34.35
       '@typeschema/class-validator': 0.3.0(@types/json-schema@7.0.15)(class-validator@0.14.2)
       '@vinejs/vine': 3.0.1
@@ -9072,7 +9072,7 @@ snapshots:
       joi: 17.13.3
       json-schema-to-ts: 3.1.1
       superstruct: 2.0.2
-      valibot: 1.1.0(typescript@5.6.3)
+      valibot: 1.1.0(typescript@5.8.3)
       yup: 1.6.1
       zod: 3.25.67
       zod-to-json-schema: 3.24.5(zod@3.25.67)
@@ -9129,12 +9129,12 @@ snapshots:
 
   tailwind-merge@3.3.1: {}
 
-  tailwind-variants@0.3.1(tailwindcss@3.4.17(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.6.3))):
+  tailwind-variants@0.3.1(tailwindcss@3.4.17(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.8.3))):
     dependencies:
       tailwind-merge: 2.5.4
-      tailwindcss: 3.4.17(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.6.3))
+      tailwindcss: 3.4.17(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.8.3))
 
-  tailwindcss@3.4.17(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.6.3)):
+  tailwindcss@3.4.17(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.8.3)):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -9153,7 +9153,7 @@ snapshots:
       postcss: 8.4.49
       postcss-import: 15.1.0(postcss@8.4.49)
       postcss-js: 4.0.1(postcss@8.4.49)
-      postcss-load-config: 4.0.2(postcss@8.4.49)(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.6.3))
+      postcss-load-config: 4.0.2(postcss@8.4.49)(ts-node@10.9.1(@types/node@24.0.3)(typescript@5.8.3))
       postcss-nested: 6.2.0(postcss@8.4.49)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.8
@@ -9161,9 +9161,9 @@ snapshots:
     transitivePeerDependencies:
       - ts-node
 
-  talt@2.4.4(typescript@5.6.3):
+  talt@2.4.4(typescript@5.8.3):
     dependencies:
-      typescript: 5.6.3
+      typescript: 5.8.3
 
   tar-fs@2.1.1:
     dependencies:
@@ -9285,9 +9285,9 @@ snapshots:
   ts-algebra@2.0.0:
     optional: true
 
-  ts-api-utils@2.1.0(typescript@5.6.3):
+  ts-api-utils@2.1.0(typescript@5.8.3):
     dependencies:
-      typescript: 5.6.3
+      typescript: 5.8.3
 
   ts-dedent@2.2.0: {}
 
@@ -9318,7 +9318,7 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
-  ts-node@10.9.1(@types/node@24.0.3)(typescript@5.6.3):
+  ts-node@10.9.1(@types/node@24.0.3)(typescript@5.8.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
@@ -9332,7 +9332,7 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 5.6.3
+      typescript: 5.8.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optional: true
@@ -9353,7 +9353,7 @@ snapshots:
 
   typescript@4.9.5: {}
 
-  typescript@5.6.3: {}
+  typescript@5.8.3: {}
 
   typical@4.0.0: {}
 
@@ -9404,14 +9404,14 @@ snapshots:
 
   v8-compile-cache-lib@3.0.1: {}
 
-  valibot@0.42.1(typescript@5.6.3):
+  valibot@0.42.1(typescript@5.8.3):
     optionalDependencies:
-      typescript: 5.6.3
+      typescript: 5.8.3
     optional: true
 
-  valibot@1.1.0(typescript@5.6.3):
+  valibot@1.1.0(typescript@5.8.3):
     optionalDependencies:
-      typescript: 5.6.3
+      typescript: 5.8.3
     optional: true
 
   validator@13.15.15:

--- a/src/routes/workbooks/[slug]/+page.svelte
+++ b/src/routes/workbooks/[slug]/+page.svelte
@@ -75,8 +75,7 @@
     return getContestIdFrom(taskId) + '-' + taskId;
   };
 
-  // HACK:: `updatingModal` is updated, but is not declared with `$state(...)`. Changing its value will not correctly trigger updates.
-  let updatingModal: UpdatingModal | null = null;
+  let updatingModal: UpdatingModal | null = $state(null);
 
   // HACK: clickを1回実行するとactionsが2回実行されてしまう。原因と修正方法が分かっていない。
   function handleClick(taskId: string) {

--- a/src/routes/workbooks/[slug]/+page.svelte
+++ b/src/routes/workbooks/[slug]/+page.svelte
@@ -75,7 +75,7 @@
     return getContestIdFrom(taskId) + '-' + taskId;
   };
 
-  let updatingModal: UpdatingModal | null = $state(null);
+  let updatingModal = $state<UpdatingModal | null>(null);
 
   // HACK: clickを1回実行するとactionsが2回実行されてしまう。原因と修正方法が分かっていない。
   function handleClick(taskId: string) {

--- a/src/routes/workbooks/create/+page.server.ts
+++ b/src/routes/workbooks/create/+page.server.ts
@@ -47,6 +47,11 @@ export const actions = {
       return fail(FORBIDDEN, { message: 'ログインが必要です。' });
     }
 
+    // Security check: Only admins can create workbooks
+    if (author.role !== Roles.ADMIN) {
+      return fail(FORBIDDEN, { message: '管理者のみ問題集を作成できます。' });
+    }
+
     const form = await superValidate(request, zod(workBookSchema));
 
     if (!form.valid) {

--- a/src/routes/workbooks/create/+page.server.ts
+++ b/src/routes/workbooks/create/+page.server.ts
@@ -65,10 +65,7 @@ export const actions = {
     }
 
     // Note: form.data includes authorId
-    const workBook = {
-      ...form.data,
-      id: 0, // Dummy id (Prisma will auto-generate it)
-    };
+    const workBook = { ...form.data };
 
     try {
       await workBooksCrud.createWorkBook(workBook);

--- a/src/routes/workbooks/edit/[slug]/+page.server.ts
+++ b/src/routes/workbooks/edit/[slug]/+page.server.ts
@@ -21,7 +21,11 @@ export async function load({ locals, params }) {
   const workBookWithAuthor = await getWorkbookWithAuthor(slug);
 
   const form = await superValidate(null, zod(workBookSchema));
-  form.data = { ...form.data, ...workBookWithAuthor.workBook };
+  const workBook = {
+    ...workBookWithAuthor.workBook,
+    urlSlug: workBookWithAuthor.workBook.urlSlug ?? undefined,
+  };
+  form.data = { ...form.data, ...workBook };
   const tasks = await tasksCrud.getTasks();
   const tasksMapByIds = await tasksCrud.getTasksByTaskId();
 


### PR DESCRIPTION
close #2199

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reactivity for modal updates in the workbook details page.
  - Ensured the form data for editing workbooks never contains a null `urlSlug`, preventing potential issues with form handling.

- **Chores**
  - Updated TypeScript to version 5.8.3.
  - Enhanced user authentication and authorization checks during workbook creation, now requiring login and admin role before proceeding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->