### PR TITLE
:books: Update url slug in workbooks (#2216)

### DIFF
--- a/prisma/workbooks.ts
+++ b/prisma/workbooks.ts
@@ -479,7 +479,7 @@ export const workbooks = [
     isPublished: true,
     isOfficial: true,
     workBookType: WorkBookType.SOLUTION,
-    urlSlug: 'union-find-with-potential',
+    urlSlug: 'potentialized-union-find',
     workBookTasks: [
       { taskId: 'abc373_d', priority: 1, comment: 'DFS・BFSでも解けます' },
       { taskId: 'abc320_d', priority: 2, comment: 'DFS・BFSでも解けます' },
@@ -502,7 +502,7 @@ export const workbooks = [
     isPublished: true,
     isOfficial: true,
     workBookType: WorkBookType.SOLUTION,
-    urlSlug: 'bit-exhaustive-search',
+    urlSlug: 'bitmask-brute-force-search',
     workBookTasks: [
       { taskId: 'abc374_c', priority: 1, comment: '' },
       { taskId: 'abc358_c', priority: 2, comment: '' },
@@ -608,6 +608,7 @@ export const workbooks = [
     isPublished: false,
     isOfficial: true,
     workBookType: WorkBookType.SOLUTION,
+    urlSlug: 'number-theory-search',
     workBookTasks: [
       { taskId: 'math_and_algorithm_l', priority: 1, comment: '' },
       { taskId: 'abc343_c', priority: 2, comment: '' },


### PR DESCRIPTION
close #2216

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a URL slug for the previously unpublished workbook "整数系探索問題（250-like Number など）".

- **Refactor**
  - Updated the URL slugs for the workbooks "ポテンシャル付き Union-Find" and "ビット全探索" to improve consistency and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->