### PR TITLE
:boom: Bump typescript from 5.8.3 to 5.9.2 (#2428)

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "svelte-meta-tags": "4.4.0",
     "sveltekit-superforms": "2.27.1",
     "tslib": "2.8.1",
-    "typescript": "5.8.3",
+    "typescript": "5.9.2",
     "vite": "7.0.6",
     "vitest": "3.2.4",
     "zod": "3.25.76"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
         version: 3.0.2(@prisma/client@5.22.0(prisma@5.22.0))(lucia@2.7.7)
       '@mermaid-js/mermaid-cli':
         specifier: 11.9.0
-        version: 11.9.0(puppeteer@19.11.1(typescript@5.8.3))(ts-node@10.9.1(@types/node@24.2.0)(typescript@5.8.3))
+        version: 11.9.0(puppeteer@19.11.1(typescript@5.9.2))(ts-node@10.9.1(@types/node@24.2.0)(typescript@5.9.2))
       '@popperjs/core':
         specifier: 2.11.8
         version: 2.11.8
@@ -58,7 +58,7 @@ importers:
         version: 1.54.2
       prisma-erd-generator:
         specifier: 2.0.4
-        version: 2.0.4(@prisma/client@5.22.0(prisma@5.22.0))(puppeteer@19.11.1(typescript@5.8.3))(ts-node@10.9.1(@types/node@24.2.0)(typescript@5.8.3))
+        version: 2.0.4(@prisma/client@5.22.0(prisma@5.22.0))(puppeteer@19.11.1(typescript@5.9.2))(ts-node@10.9.1(@types/node@24.2.0)(typescript@5.9.2))
       svelte-eslint-parser:
         specifier: 1.3.1
         version: 1.3.1(svelte@5.37.3)
@@ -67,7 +67,7 @@ importers:
         version: 2.6.0
       tailwindcss:
         specifier: 3.4.17
-        version: 3.4.17(ts-node@10.9.1(@types/node@24.2.0)(typescript@5.8.3))
+        version: 3.4.17(ts-node@10.9.1(@types/node@24.2.0)(typescript@5.9.2))
       vercel:
         specifier: 44.7.3
         version: 44.7.3(rollup@4.45.1)
@@ -86,7 +86,7 @@ importers:
         version: 1.54.2
       '@quramy/prisma-fabbrica':
         specifier: 2.3.0
-        version: 2.3.0(@prisma/client@5.22.0(prisma@5.22.0))(typescript@5.8.3)
+        version: 2.3.0(@prisma/client@5.22.0(prisma@5.22.0))(typescript@5.9.2)
       '@sveltejs/adapter-vercel':
         specifier: 5.8.1
         version: 5.8.1(@sveltejs/kit@2.27.1(@sveltejs/vite-plugin-svelte@6.1.0(svelte@5.37.3)(vite@7.0.6(@types/node@24.2.0)(jiti@1.21.6)(yaml@2.8.0)))(svelte@5.37.3)(vite@7.0.6(@types/node@24.2.0)(jiti@1.21.6)(yaml@2.8.0)))(rollup@4.45.1)
@@ -98,7 +98,7 @@ importers:
         version: 6.1.0(svelte@5.37.3)(vite@7.0.6(@types/node@24.2.0)(jiti@1.21.6)(yaml@2.8.0))
       '@tailwindcss/forms':
         specifier: 0.5.10
-        version: 0.5.10(tailwindcss@3.4.17(ts-node@10.9.1(@types/node@24.2.0)(typescript@5.8.3)))
+        version: 0.5.10(tailwindcss@3.4.17(ts-node@10.9.1(@types/node@24.2.0)(typescript@5.9.2)))
       '@testing-library/jest-dom':
         specifier: 6.6.4
         version: 6.6.4
@@ -110,10 +110,10 @@ importers:
         version: 21.1.7
       '@typescript-eslint/eslint-plugin':
         specifier: 8.39.0
-        version: 8.39.0(@typescript-eslint/parser@8.39.0(eslint@9.32.0(jiti@1.21.6))(typescript@5.8.3))(eslint@9.32.0(jiti@1.21.6))(typescript@5.8.3)
+        version: 8.39.0(@typescript-eslint/parser@8.39.0(eslint@9.32.0(jiti@1.21.6))(typescript@5.9.2))(eslint@9.32.0(jiti@1.21.6))(typescript@5.9.2)
       '@typescript-eslint/parser':
         specifier: 8.39.0
-        version: 8.39.0(eslint@9.32.0(jiti@1.21.6))(typescript@5.8.3)
+        version: 8.39.0(eslint@9.32.0(jiti@1.21.6))(typescript@5.9.2)
       '@vitest/coverage-v8':
         specifier: 3.2.4
         version: 3.2.4(vitest@3.2.4)
@@ -128,7 +128,7 @@ importers:
         version: 10.1.8(eslint@9.32.0(jiti@1.21.6))
       eslint-plugin-svelte:
         specifier: 3.10.1
-        version: 3.10.1(eslint@9.32.0(jiti@1.21.6))(svelte@5.37.3)(ts-node@10.9.1(@types/node@24.2.0)(typescript@5.8.3))
+        version: 3.10.1(eslint@9.32.0(jiti@1.21.6))(svelte@5.37.3)(ts-node@10.9.1(@types/node@24.2.0)(typescript@5.9.2))
       globals:
         specifier: 16.3.0
         version: 16.3.0
@@ -167,22 +167,22 @@ importers:
         version: 5.37.3
       svelte-5-ui-lib:
         specifier: 0.12.2
-        version: 0.12.2(svelte@5.37.3)(tailwindcss@3.4.17(ts-node@10.9.1(@types/node@24.2.0)(typescript@5.8.3)))
+        version: 0.12.2(svelte@5.37.3)(tailwindcss@3.4.17(ts-node@10.9.1(@types/node@24.2.0)(typescript@5.9.2)))
       svelte-check:
         specifier: 4.3.1
-        version: 4.3.1(picomatch@4.0.3)(svelte@5.37.3)(typescript@5.8.3)
+        version: 4.3.1(picomatch@4.0.3)(svelte@5.37.3)(typescript@5.9.2)
       svelte-meta-tags:
         specifier: 4.4.0
         version: 4.4.0(svelte@5.37.3)
       sveltekit-superforms:
         specifier: 2.27.1
-        version: 2.27.1(@sveltejs/kit@2.27.1(@sveltejs/vite-plugin-svelte@6.1.0(svelte@5.37.3)(vite@7.0.6(@types/node@24.2.0)(jiti@1.21.6)(yaml@2.8.0)))(svelte@5.37.3)(vite@7.0.6(@types/node@24.2.0)(jiti@1.21.6)(yaml@2.8.0)))(@types/json-schema@7.0.15)(esbuild@0.25.8)(svelte@5.37.3)(typescript@5.8.3)
+        version: 2.27.1(@sveltejs/kit@2.27.1(@sveltejs/vite-plugin-svelte@6.1.0(svelte@5.37.3)(vite@7.0.6(@types/node@24.2.0)(jiti@1.21.6)(yaml@2.8.0)))(svelte@5.37.3)(vite@7.0.6(@types/node@24.2.0)(jiti@1.21.6)(yaml@2.8.0)))(@types/json-schema@7.0.15)(esbuild@0.25.8)(svelte@5.37.3)(typescript@5.9.2)
       tslib:
         specifier: 2.8.1
         version: 2.8.1
       typescript:
-        specifier: 5.8.3
-        version: 5.8.3
+        specifier: 5.9.2
+        version: 5.9.2
       vite:
         specifier: 7.0.6
         version: 7.0.6(@types/node@24.2.0)(jiti@1.21.6)(yaml@2.8.0)
@@ -4202,8 +4202,8 @@ packages:
     engines: {node: '>=4.2.0'}
     hasBin: true
 
-  typescript@5.8.3:
-    resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
+  typescript@5.9.2:
+    resolution: {integrity: sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -4850,9 +4850,9 @@ snapshots:
 
   '@floating-ui/utils@0.2.9': {}
 
-  '@gcornut/valibot-json-schema@0.42.0(esbuild@0.25.8)(typescript@5.8.3)':
+  '@gcornut/valibot-json-schema@0.42.0(esbuild@0.25.8)(typescript@5.9.2)':
     dependencies:
-      valibot: 0.42.1(typescript@5.8.3)
+      valibot: 0.42.1(typescript@5.9.2)
     optionalDependencies:
       '@types/json-schema': 7.0.15
       esbuild-runner: 2.2.2(esbuild@0.25.8)
@@ -4879,9 +4879,9 @@ snapshots:
       react-dom: 19.1.1(react@19.1.1)
       use-sync-external-store: 1.5.0(react@19.1.1)
 
-  '@headlessui/tailwindcss@0.2.2(tailwindcss@3.4.17(ts-node@10.9.1(@types/node@24.2.0)(typescript@5.8.3)))':
+  '@headlessui/tailwindcss@0.2.2(tailwindcss@3.4.17(ts-node@10.9.1(@types/node@24.2.0)(typescript@5.9.2)))':
     dependencies:
-      tailwindcss: 3.4.17(ts-node@10.9.1(@types/node@24.2.0)(typescript@5.8.3))
+      tailwindcss: 3.4.17(ts-node@10.9.1(@types/node@24.2.0)(typescript@5.9.2))
 
   '@humanfs/core@0.19.1': {}
 
@@ -5000,22 +5000,22 @@ snapshots:
       - encoding
       - supports-color
 
-  '@mermaid-js/mermaid-cli@11.9.0(puppeteer@19.11.1(typescript@5.8.3))(ts-node@10.9.1(@types/node@24.2.0)(typescript@5.8.3))':
+  '@mermaid-js/mermaid-cli@11.9.0(puppeteer@19.11.1(typescript@5.9.2))(ts-node@10.9.1(@types/node@24.2.0)(typescript@5.9.2))':
     dependencies:
-      '@mermaid-js/mermaid-zenuml': 0.2.1(mermaid@11.9.0)(ts-node@10.9.1(@types/node@24.2.0)(typescript@5.8.3))
+      '@mermaid-js/mermaid-zenuml': 0.2.1(mermaid@11.9.0)(ts-node@10.9.1(@types/node@24.2.0)(typescript@5.9.2))
       chalk: 5.4.1
       commander: 14.0.0
       import-meta-resolve: 4.1.0
       mermaid: 11.9.0
-      puppeteer: 19.11.1(typescript@5.8.3)
+      puppeteer: 19.11.1(typescript@5.9.2)
     transitivePeerDependencies:
       - '@types/react'
       - supports-color
       - ts-node
 
-  '@mermaid-js/mermaid-zenuml@0.2.1(mermaid@11.9.0)(ts-node@10.9.1(@types/node@24.2.0)(typescript@5.8.3))':
+  '@mermaid-js/mermaid-zenuml@0.2.1(mermaid@11.9.0)(ts-node@10.9.1(@types/node@24.2.0)(typescript@5.9.2))':
     dependencies:
-      '@zenuml/core': 3.36.0(ts-node@10.9.1(@types/node@24.2.0)(typescript@5.8.3))
+      '@zenuml/core': 3.36.0(ts-node@10.9.1(@types/node@24.2.0)(typescript@5.9.2))
       mermaid: 11.9.0
     transitivePeerDependencies:
       - '@types/react'
@@ -5142,7 +5142,7 @@ snapshots:
     dependencies:
       '@prisma/debug': 6.7.0
 
-  '@prisma/internals@6.7.0(typescript@5.8.3)':
+  '@prisma/internals@6.7.0(typescript@5.9.2)':
     dependencies:
       '@prisma/config': 6.7.0
       '@prisma/debug': 6.7.0
@@ -5159,7 +5159,7 @@ snapshots:
       arg: 5.0.2
       prompts: 2.4.2
     optionalDependencies:
-      typescript: 5.8.3
+      typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
 
@@ -5172,7 +5172,7 @@ snapshots:
       '@prisma/prisma-schema-wasm': 6.7.0-36.3cff47a7f5d65c3ea74883f1d736e41d68ce91ed
       fs-extra: 11.3.0
 
-  '@puppeteer/browsers@0.5.0(typescript@5.8.3)':
+  '@puppeteer/browsers@0.5.0(typescript@5.9.2)':
     dependencies:
       debug: 4.3.4
       extract-zip: 2.0.1
@@ -5183,18 +5183,18 @@ snapshots:
       unbzip2-stream: 1.4.3
       yargs: 17.7.1
     optionalDependencies:
-      typescript: 5.8.3
+      typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
 
-  '@quramy/prisma-fabbrica@2.3.0(@prisma/client@5.22.0(prisma@5.22.0))(typescript@5.8.3)':
+  '@quramy/prisma-fabbrica@2.3.0(@prisma/client@5.22.0(prisma@5.22.0))(typescript@5.9.2)':
     dependencies:
       '@prisma/client': 5.22.0(prisma@5.22.0)
       '@prisma/generator-helper': 6.7.0
-      '@prisma/internals': 6.7.0(typescript@5.8.3)
+      '@prisma/internals': 6.7.0(typescript@5.9.2)
       short-uuid: 5.2.0
-      talt: 2.4.4(typescript@5.8.3)
-      typescript: 5.8.3
+      talt: 2.4.4(typescript@5.9.2)
+      typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
 
@@ -5402,10 +5402,10 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@tailwindcss/forms@0.5.10(tailwindcss@3.4.17(ts-node@10.9.1(@types/node@24.2.0)(typescript@5.8.3)))':
+  '@tailwindcss/forms@0.5.10(tailwindcss@3.4.17(ts-node@10.9.1(@types/node@24.2.0)(typescript@5.9.2)))':
     dependencies:
       mini-svg-data-uri: 1.4.4
-      tailwindcss: 3.4.17(ts-node@10.9.1(@types/node@24.2.0)(typescript@5.8.3))
+      tailwindcss: 3.4.17(ts-node@10.9.1(@types/node@24.2.0)(typescript@5.9.2))
 
   '@tanstack/react-virtual@3.13.12(react-dom@19.1.1(react@19.1.1))(react@19.1.1)':
     dependencies:
@@ -5660,41 +5660,41 @@ snapshots:
       '@types/json-schema': 7.0.15
     optional: true
 
-  '@typescript-eslint/eslint-plugin@8.39.0(@typescript-eslint/parser@8.39.0(eslint@9.32.0(jiti@1.21.6))(typescript@5.8.3))(eslint@9.32.0(jiti@1.21.6))(typescript@5.8.3)':
+  '@typescript-eslint/eslint-plugin@8.39.0(@typescript-eslint/parser@8.39.0(eslint@9.32.0(jiti@1.21.6))(typescript@5.9.2))(eslint@9.32.0(jiti@1.21.6))(typescript@5.9.2)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.39.0(eslint@9.32.0(jiti@1.21.6))(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.39.0(eslint@9.32.0(jiti@1.21.6))(typescript@5.9.2)
       '@typescript-eslint/scope-manager': 8.39.0
-      '@typescript-eslint/type-utils': 8.39.0(eslint@9.32.0(jiti@1.21.6))(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.39.0(eslint@9.32.0(jiti@1.21.6))(typescript@5.8.3)
+      '@typescript-eslint/type-utils': 8.39.0(eslint@9.32.0(jiti@1.21.6))(typescript@5.9.2)
+      '@typescript-eslint/utils': 8.39.0(eslint@9.32.0(jiti@1.21.6))(typescript@5.9.2)
       '@typescript-eslint/visitor-keys': 8.39.0
       eslint: 9.32.0(jiti@1.21.6)
       graphemer: 1.4.0
       ignore: 7.0.5
       natural-compare: 1.4.0
-      ts-api-utils: 2.1.0(typescript@5.8.3)
-      typescript: 5.8.3
+      ts-api-utils: 2.1.0(typescript@5.9.2)
+      typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.39.0(eslint@9.32.0(jiti@1.21.6))(typescript@5.8.3)':
+  '@typescript-eslint/parser@8.39.0(eslint@9.32.0(jiti@1.21.6))(typescript@5.9.2)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.39.0
       '@typescript-eslint/types': 8.39.0
-      '@typescript-eslint/typescript-estree': 8.39.0(typescript@5.8.3)
+      '@typescript-eslint/typescript-estree': 8.39.0(typescript@5.9.2)
       '@typescript-eslint/visitor-keys': 8.39.0
       debug: 4.4.1
       eslint: 9.32.0(jiti@1.21.6)
-      typescript: 5.8.3
+      typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.39.0(typescript@5.8.3)':
+  '@typescript-eslint/project-service@8.39.0(typescript@5.9.2)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.39.0(typescript@5.8.3)
+      '@typescript-eslint/tsconfig-utils': 8.39.0(typescript@5.9.2)
       '@typescript-eslint/types': 8.39.0
       debug: 4.4.1
-      typescript: 5.8.3
+      typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
 
@@ -5703,28 +5703,28 @@ snapshots:
       '@typescript-eslint/types': 8.39.0
       '@typescript-eslint/visitor-keys': 8.39.0
 
-  '@typescript-eslint/tsconfig-utils@8.39.0(typescript@5.8.3)':
+  '@typescript-eslint/tsconfig-utils@8.39.0(typescript@5.9.2)':
     dependencies:
-      typescript: 5.8.3
+      typescript: 5.9.2
 
-  '@typescript-eslint/type-utils@8.39.0(eslint@9.32.0(jiti@1.21.6))(typescript@5.8.3)':
+  '@typescript-eslint/type-utils@8.39.0(eslint@9.32.0(jiti@1.21.6))(typescript@5.9.2)':
     dependencies:
       '@typescript-eslint/types': 8.39.0
-      '@typescript-eslint/typescript-estree': 8.39.0(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.39.0(eslint@9.32.0(jiti@1.21.6))(typescript@5.8.3)
+      '@typescript-eslint/typescript-estree': 8.39.0(typescript@5.9.2)
+      '@typescript-eslint/utils': 8.39.0(eslint@9.32.0(jiti@1.21.6))(typescript@5.9.2)
       debug: 4.4.1
       eslint: 9.32.0(jiti@1.21.6)
-      ts-api-utils: 2.1.0(typescript@5.8.3)
-      typescript: 5.8.3
+      ts-api-utils: 2.1.0(typescript@5.9.2)
+      typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
 
   '@typescript-eslint/types@8.39.0': {}
 
-  '@typescript-eslint/typescript-estree@8.39.0(typescript@5.8.3)':
+  '@typescript-eslint/typescript-estree@8.39.0(typescript@5.9.2)':
     dependencies:
-      '@typescript-eslint/project-service': 8.39.0(typescript@5.8.3)
-      '@typescript-eslint/tsconfig-utils': 8.39.0(typescript@5.8.3)
+      '@typescript-eslint/project-service': 8.39.0(typescript@5.9.2)
+      '@typescript-eslint/tsconfig-utils': 8.39.0(typescript@5.9.2)
       '@typescript-eslint/types': 8.39.0
       '@typescript-eslint/visitor-keys': 8.39.0
       debug: 4.4.1
@@ -5732,19 +5732,19 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.5
       semver: 7.7.2
-      ts-api-utils: 2.1.0(typescript@5.8.3)
-      typescript: 5.8.3
+      ts-api-utils: 2.1.0(typescript@5.9.2)
+      typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.39.0(eslint@9.32.0(jiti@1.21.6))(typescript@5.8.3)':
+  '@typescript-eslint/utils@8.39.0(eslint@9.32.0(jiti@1.21.6))(typescript@5.9.2)':
     dependencies:
       '@eslint-community/eslint-utils': 4.7.0(eslint@9.32.0(jiti@1.21.6))
       '@typescript-eslint/scope-manager': 8.39.0
       '@typescript-eslint/types': 8.39.0
-      '@typescript-eslint/typescript-estree': 8.39.0(typescript@5.8.3)
+      '@typescript-eslint/typescript-estree': 8.39.0(typescript@5.9.2)
       eslint: 9.32.0(jiti@1.21.6)
-      typescript: 5.8.3
+      typescript: 5.9.2
     transitivePeerDependencies:
       - supports-color
 
@@ -6026,11 +6026,11 @@ snapshots:
 
   '@yr/monotone-cubic-spline@1.0.3': {}
 
-  '@zenuml/core@3.36.0(ts-node@10.9.1(@types/node@24.2.0)(typescript@5.8.3))':
+  '@zenuml/core@3.36.0(ts-node@10.9.1(@types/node@24.2.0)(typescript@5.9.2))':
     dependencies:
       '@floating-ui/react': 0.27.14(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       '@headlessui/react': 2.2.6(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@headlessui/tailwindcss': 0.2.2(tailwindcss@3.4.17(ts-node@10.9.1(@types/node@24.2.0)(typescript@5.8.3)))
+      '@headlessui/tailwindcss': 0.2.2(tailwindcss@3.4.17(ts-node@10.9.1(@types/node@24.2.0)(typescript@5.9.2)))
       antlr4: 4.11.0
       class-variance-authority: 0.7.1
       clsx: 2.1.1
@@ -6048,7 +6048,7 @@ snapshots:
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
       tailwind-merge: 3.3.1
-      tailwindcss: 3.4.17(ts-node@10.9.1(@types/node@24.2.0)(typescript@5.8.3))
+      tailwindcss: 3.4.17(ts-node@10.9.1(@types/node@24.2.0)(typescript@5.9.2))
     transitivePeerDependencies:
       - '@types/react'
       - ts-node
@@ -6906,7 +6906,7 @@ snapshots:
     dependencies:
       eslint: 9.32.0(jiti@1.21.6)
 
-  eslint-plugin-svelte@3.10.1(eslint@9.32.0(jiti@1.21.6))(svelte@5.37.3)(ts-node@10.9.1(@types/node@24.2.0)(typescript@5.8.3)):
+  eslint-plugin-svelte@3.10.1(eslint@9.32.0(jiti@1.21.6))(svelte@5.37.3)(ts-node@10.9.1(@types/node@24.2.0)(typescript@5.9.2)):
     dependencies:
       '@eslint-community/eslint-utils': 4.7.0(eslint@9.32.0(jiti@1.21.6))
       '@jridgewell/sourcemap-codec': 1.5.0
@@ -6915,7 +6915,7 @@ snapshots:
       globals: 16.3.0
       known-css-properties: 0.37.0
       postcss: 8.5.6
-      postcss-load-config: 3.1.4(postcss@8.5.6)(ts-node@10.9.1(@types/node@24.2.0)(typescript@5.8.3))
+      postcss-load-config: 3.1.4(postcss@8.5.6)(ts-node@10.9.1(@types/node@24.2.0)(typescript@5.9.2))
       postcss-safe-parser: 7.0.1(postcss@8.5.6)
       semver: 7.7.2
       svelte-eslint-parser: 1.3.1(svelte@5.37.3)
@@ -7950,21 +7950,21 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.4.49
 
-  postcss-load-config@3.1.4(postcss@8.5.6)(ts-node@10.9.1(@types/node@24.2.0)(typescript@5.8.3)):
+  postcss-load-config@3.1.4(postcss@8.5.6)(ts-node@10.9.1(@types/node@24.2.0)(typescript@5.9.2)):
     dependencies:
       lilconfig: 2.1.0
       yaml: 1.10.2
     optionalDependencies:
       postcss: 8.5.6
-      ts-node: 10.9.1(@types/node@24.2.0)(typescript@5.8.3)
+      ts-node: 10.9.1(@types/node@24.2.0)(typescript@5.9.2)
 
-  postcss-load-config@4.0.2(postcss@8.4.49)(ts-node@10.9.1(@types/node@24.2.0)(typescript@5.8.3)):
+  postcss-load-config@4.0.2(postcss@8.4.49)(ts-node@10.9.1(@types/node@24.2.0)(typescript@5.9.2)):
     dependencies:
       lilconfig: 3.1.3
       yaml: 2.8.0
     optionalDependencies:
       postcss: 8.4.49
-      ts-node: 10.9.1(@types/node@24.2.0)(typescript@5.8.3)
+      ts-node: 10.9.1(@types/node@24.2.0)(typescript@5.9.2)
 
   postcss-nested@6.2.0(postcss@8.4.49):
     dependencies:
@@ -8034,9 +8034,9 @@ snapshots:
     dependencies:
       parse-ms: 2.1.0
 
-  prisma-erd-generator@2.0.4(@prisma/client@5.22.0(prisma@5.22.0))(puppeteer@19.11.1(typescript@5.8.3))(ts-node@10.9.1(@types/node@24.2.0)(typescript@5.8.3)):
+  prisma-erd-generator@2.0.4(@prisma/client@5.22.0(prisma@5.22.0))(puppeteer@19.11.1(typescript@5.9.2))(ts-node@10.9.1(@types/node@24.2.0)(typescript@5.9.2)):
     dependencies:
-      '@mermaid-js/mermaid-cli': 11.9.0(puppeteer@19.11.1(typescript@5.8.3))(ts-node@10.9.1(@types/node@24.2.0)(typescript@5.8.3))
+      '@mermaid-js/mermaid-cli': 11.9.0(puppeteer@19.11.1(typescript@5.9.2))(ts-node@10.9.1(@types/node@24.2.0)(typescript@5.9.2))
       '@prisma/client': 5.22.0(prisma@5.22.0)
       '@prisma/generator-helper': 6.3.0
       dotenv: 16.4.7
@@ -8079,9 +8079,9 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  puppeteer-core@19.11.1(typescript@5.8.3):
+  puppeteer-core@19.11.1(typescript@5.9.2):
     dependencies:
-      '@puppeteer/browsers': 0.5.0(typescript@5.8.3)
+      '@puppeteer/browsers': 0.5.0(typescript@5.9.2)
       chromium-bidi: 0.4.7(devtools-protocol@0.0.1107588)
       cross-fetch: 3.1.5
       debug: 4.3.4
@@ -8093,21 +8093,21 @@ snapshots:
       unbzip2-stream: 1.4.3
       ws: 8.13.0
     optionalDependencies:
-      typescript: 5.8.3
+      typescript: 5.9.2
     transitivePeerDependencies:
       - bufferutil
       - encoding
       - supports-color
       - utf-8-validate
 
-  puppeteer@19.11.1(typescript@5.8.3):
+  puppeteer@19.11.1(typescript@5.9.2):
     dependencies:
-      '@puppeteer/browsers': 0.5.0(typescript@5.8.3)
+      '@puppeteer/browsers': 0.5.0(typescript@5.9.2)
       cosmiconfig: 8.1.3
       https-proxy-agent: 5.0.1
       progress: 2.0.3
       proxy-from-env: 1.1.0
-      puppeteer-core: 19.11.1(typescript@5.8.3)
+      puppeteer-core: 19.11.1(typescript@5.9.2)
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -8430,17 +8430,17 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svelte-5-ui-lib@0.12.2(svelte@5.37.3)(tailwindcss@3.4.17(ts-node@10.9.1(@types/node@24.2.0)(typescript@5.8.3))):
+  svelte-5-ui-lib@0.12.2(svelte@5.37.3)(tailwindcss@3.4.17(ts-node@10.9.1(@types/node@24.2.0)(typescript@5.9.2))):
     dependencies:
       '@floating-ui/dom': 1.6.13
       apexcharts: 3.54.1
       clsx: 2.1.1
       svelte: 5.37.3
       tailwind-merge: 2.6.0
-      tailwind-variants: 0.3.1(tailwindcss@3.4.17(ts-node@10.9.1(@types/node@24.2.0)(typescript@5.8.3)))
-      tailwindcss: 3.4.17(ts-node@10.9.1(@types/node@24.2.0)(typescript@5.8.3))
+      tailwind-variants: 0.3.1(tailwindcss@3.4.17(ts-node@10.9.1(@types/node@24.2.0)(typescript@5.9.2)))
+      tailwindcss: 3.4.17(ts-node@10.9.1(@types/node@24.2.0)(typescript@5.9.2))
 
-  svelte-check@4.3.1(picomatch@4.0.3)(svelte@5.37.3)(typescript@5.8.3):
+  svelte-check@4.3.1(picomatch@4.0.3)(svelte@5.37.3)(typescript@5.9.2):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.29
       chokidar: 4.0.3
@@ -8448,7 +8448,7 @@ snapshots:
       picocolors: 1.1.1
       sade: 1.8.1
       svelte: 5.37.3
-      typescript: 5.8.3
+      typescript: 5.9.2
     transitivePeerDependencies:
       - picomatch
 
@@ -8485,7 +8485,7 @@ snapshots:
       magic-string: 0.30.17
       zimmerframe: 1.1.2
 
-  sveltekit-superforms@2.27.1(@sveltejs/kit@2.27.1(@sveltejs/vite-plugin-svelte@6.1.0(svelte@5.37.3)(vite@7.0.6(@types/node@24.2.0)(jiti@1.21.6)(yaml@2.8.0)))(svelte@5.37.3)(vite@7.0.6(@types/node@24.2.0)(jiti@1.21.6)(yaml@2.8.0)))(@types/json-schema@7.0.15)(esbuild@0.25.8)(svelte@5.37.3)(typescript@5.8.3):
+  sveltekit-superforms@2.27.1(@sveltejs/kit@2.27.1(@sveltejs/vite-plugin-svelte@6.1.0(svelte@5.37.3)(vite@7.0.6(@types/node@24.2.0)(jiti@1.21.6)(yaml@2.8.0)))(svelte@5.37.3)(vite@7.0.6(@types/node@24.2.0)(jiti@1.21.6)(yaml@2.8.0)))(@types/json-schema@7.0.15)(esbuild@0.25.8)(svelte@5.37.3)(typescript@5.9.2):
     dependencies:
       '@sveltejs/kit': 2.27.1(@sveltejs/vite-plugin-svelte@6.1.0(svelte@5.37.3)(vite@7.0.6(@types/node@24.2.0)(jiti@1.21.6)(yaml@2.8.0)))(svelte@5.37.3)(vite@7.0.6(@types/node@24.2.0)(jiti@1.21.6)(yaml@2.8.0))
       devalue: 5.1.1
@@ -8494,7 +8494,7 @@ snapshots:
       ts-deepmerge: 7.0.3
     optionalDependencies:
       '@exodus/schemasafe': 1.3.0
-      '@gcornut/valibot-json-schema': 0.42.0(esbuild@0.25.8)(typescript@5.8.3)
+      '@gcornut/valibot-json-schema': 0.42.0(esbuild@0.25.8)(typescript@5.9.2)
       '@sinclair/typebox': 0.34.37
       '@typeschema/class-validator': 0.3.0(@types/json-schema@7.0.15)(class-validator@0.14.2)
       '@vinejs/vine': 3.0.1
@@ -8504,7 +8504,7 @@ snapshots:
       joi: 17.13.3
       json-schema-to-ts: 3.1.1
       superstruct: 2.0.2
-      valibot: 1.1.0(typescript@5.8.3)
+      valibot: 1.1.0(typescript@5.9.2)
       yup: 1.6.1
       zod: 3.25.76
       zod-to-json-schema: 3.24.6(zod@3.25.76)
@@ -8561,12 +8561,12 @@ snapshots:
 
   tailwind-merge@3.3.1: {}
 
-  tailwind-variants@0.3.1(tailwindcss@3.4.17(ts-node@10.9.1(@types/node@24.2.0)(typescript@5.8.3))):
+  tailwind-variants@0.3.1(tailwindcss@3.4.17(ts-node@10.9.1(@types/node@24.2.0)(typescript@5.9.2))):
     dependencies:
       tailwind-merge: 2.5.4
-      tailwindcss: 3.4.17(ts-node@10.9.1(@types/node@24.2.0)(typescript@5.8.3))
+      tailwindcss: 3.4.17(ts-node@10.9.1(@types/node@24.2.0)(typescript@5.9.2))
 
-  tailwindcss@3.4.17(ts-node@10.9.1(@types/node@24.2.0)(typescript@5.8.3)):
+  tailwindcss@3.4.17(ts-node@10.9.1(@types/node@24.2.0)(typescript@5.9.2)):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -8585,7 +8585,7 @@ snapshots:
       postcss: 8.4.49
       postcss-import: 15.1.0(postcss@8.4.49)
       postcss-js: 4.0.1(postcss@8.4.49)
-      postcss-load-config: 4.0.2(postcss@8.4.49)(ts-node@10.9.1(@types/node@24.2.0)(typescript@5.8.3))
+      postcss-load-config: 4.0.2(postcss@8.4.49)(ts-node@10.9.1(@types/node@24.2.0)(typescript@5.9.2))
       postcss-nested: 6.2.0(postcss@8.4.49)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.8
@@ -8593,9 +8593,9 @@ snapshots:
     transitivePeerDependencies:
       - ts-node
 
-  talt@2.4.4(typescript@5.8.3):
+  talt@2.4.4(typescript@5.9.2):
     dependencies:
-      typescript: 5.8.3
+      typescript: 5.9.2
 
   tar-fs@2.1.1:
     dependencies:
@@ -8708,9 +8708,9 @@ snapshots:
   ts-algebra@2.0.0:
     optional: true
 
-  ts-api-utils@2.1.0(typescript@5.8.3):
+  ts-api-utils@2.1.0(typescript@5.9.2):
     dependencies:
-      typescript: 5.8.3
+      typescript: 5.9.2
 
   ts-dedent@2.2.0: {}
 
@@ -8741,7 +8741,7 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
-  ts-node@10.9.1(@types/node@24.2.0)(typescript@5.8.3):
+  ts-node@10.9.1(@types/node@24.2.0)(typescript@5.9.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
@@ -8755,7 +8755,7 @@ snapshots:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 5.8.3
+      typescript: 5.9.2
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optional: true
@@ -8776,7 +8776,7 @@ snapshots:
 
   typescript@4.9.5: {}
 
-  typescript@5.8.3: {}
+  typescript@5.9.2: {}
 
   typical@4.0.0: {}
 
@@ -8827,14 +8827,14 @@ snapshots:
 
   v8-compile-cache-lib@3.0.1: {}
 
-  valibot@0.42.1(typescript@5.8.3):
+  valibot@0.42.1(typescript@5.9.2):
     optionalDependencies:
-      typescript: 5.8.3
+      typescript: 5.9.2
     optional: true
 
-  valibot@1.1.0(typescript@5.8.3):
+  valibot@1.1.0(typescript@5.9.2):
     optionalDependencies:
-      typescript: 5.8.3
+      typescript: 5.9.2
     optional: true
 
   validator@13.15.15:

--- a/src/lib/services/workbook_tasks.ts
+++ b/src/lib/services/workbook_tasks.ts
@@ -1,6 +1,6 @@
 import type { WorkBook, WorkBookTaskBase, WorkBookTasksBase } from '$lib/types/workbook';
 
-export async function getWorkBookTasks(workBook: WorkBook): Promise<WorkBookTasksBase> {
+export async function getWorkBookTasks(workBook: Omit<WorkBook, 'id'>): Promise<WorkBookTasksBase> {
   const workBookTasks: WorkBookTasksBase = await Promise.all(
     workBook.workBookTasks.map(async (workBookTask: WorkBookTaskBase) => {
       return {

--- a/src/lib/services/workbooks.ts
+++ b/src/lib/services/workbooks.ts
@@ -63,7 +63,7 @@ export async function getWorkBookByUrlSlug(urlSlug: string): Promise<WorkBook | 
 
 // See:
 // https://www.prisma.io/docs/orm/prisma-schema/data-model/relations#create-a-record-and-nested-records
-export async function createWorkBook(workBook: WorkBook): Promise<void> {
+export async function createWorkBook(workBook: Omit<WorkBook, 'id'>): Promise<void> {
   const slug = workBook.urlSlug;
 
   if (slug && (await isExistingUrlSlug(slug))) {


### PR DESCRIPTION
close #2428

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TypeScript development dependency to version 5.9.2.

* **Refactor**
  * Adjusted workbook-related functions to accept input objects without an `id` property.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->