### PR TITLE
✨ Add tasks and tests (#2508)

### DIFF
--- a/src/lib/utils/contest.ts
+++ b/src/lib/utils/contest.ts
@@ -179,6 +179,7 @@ const ATCODER_OTHERS: ContestPrefix = {
   'dwacon2017-prelims': '第3回 ドワンゴからの挑戦状 予選',
   'mujin-pc-2016': 'Mujin Programming Challenge 2016',
   'mujin-pc-2018': 'Mujin Programming Challenge 2018',
+  'tenka1-2015-quala': '天下一プログラマーコンテスト2015予選A',
   'tenka1-2016-final': '天下一プログラマーコンテスト2016本戦',
   // Discovery Channel contest featuring algorithm problems
   discovery2016: 'DISCO presents ディスカバリーチャンネル プログラミングコンテスト2016',

--- a/src/lib/utils/contest.ts
+++ b/src/lib/utils/contest.ts
@@ -197,6 +197,7 @@ export const AOJ_COURSES: ContestPrefix = {
   ALDS1: 'アルゴリズムとデータ構造入門',
   ITP2: 'プログラミング応用',
   DPL: '組み合わせ最適化',
+  GRL: 'グラフ',
 } as const;
 
 export function getPrefixForAojCourses() {

--- a/src/test/lib/utils/test_cases/contest_name_and_task_index.ts
+++ b/src/test/lib/utils/test_cases/contest_name_and_task_index.ts
@@ -579,6 +579,10 @@ const AOJ_COURSES_TEST_DATA = {
     contestId: 'DPL',
     tasks: ['1_A', '1_I', '5_A', '5_L'],
   },
+  GRL: {
+    contestId: 'GRL',
+    tasks: ['1_A', '1_C', '6_B', '7_A'],
+  },
 };
 
 const generateAojCoursesTestCases = (

--- a/src/test/lib/utils/test_cases/contest_type.ts
+++ b/src/test/lib/utils/test_cases/contest_type.ts
@@ -420,6 +420,7 @@ const aojCoursesData = [
   { name: 'AOJ Courses, ALDS1', contestId: 'ALDS1' },
   { name: 'AOJ Courses, ITP2', contestId: 'ITP2' },
   { name: 'AOJ Courses, DPL', contestId: 'DPL' },
+  { name: 'AOJ Courses, GRL', contestId: 'GRL' },
 ];
 
 export const aojCourses = aojCoursesData.map(({ name, contestId }) =>

--- a/src/test/lib/utils/test_cases/contest_type.ts
+++ b/src/test/lib/utils/test_cases/contest_type.ts
@@ -371,6 +371,10 @@ export const atCoderOthers = [
     contestId: 'mujin-pc-2018',
     expected: ContestType.OTHERS,
   }),
+  createTestCaseForContestType('天下一プログラマーコンテスト2015予選A')({
+    contestId: 'tenka1-2015-quala',
+    expected: ContestType.OTHERS,
+  }),
   createTestCaseForContestType('天下一プログラマーコンテスト2016本戦')({
     contestId: 'tenka1-2016-final',
     expected: ContestType.OTHERS,

--- a/src/test/lib/utils/test_cases/task_url.ts
+++ b/src/test/lib/utils/test_cases/task_url.ts
@@ -100,6 +100,10 @@ const courses = [
     contestId: 'DPL',
     tasks: ['1_A', '1_I', '5_A', '5_L'],
   },
+  {
+    contestId: 'GRL',
+    tasks: ['1_A', '1_C', '6_B', '7_A'],
+  },
 ];
 
 export const aojCourses = courses.flatMap((course) =>


### PR DESCRIPTION
close #2508

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded contest recognition to include AtCoder “Others” contest tenka1-2015-quala (天下一プログラマーコンテスト2015予選A).
  * Added AOJ course prefix GRL (グラフ), improving labeling and task handling for AOJ Courses.

* **Tests**
  * Added test cases for contest type detection and task URL generation covering the new AtCoder entry and AOJ GRL course.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->