### PR TITLE
chore(ui): Use justify-start in 640px or larger (#2783)

### DIFF
--- a/src/lib/components/TaskTables/TaskTable.svelte
+++ b/src/lib/components/TaskTables/TaskTable.svelte
@@ -171,7 +171,7 @@
 
 <!-- See: -->
 <!-- https://flowbite-svelte.com/docs/components/button-group -->
-<div class="flex justify-center m-4">
+<div class="flex justify-center md:justify-start m-4">
   <ButtonGroup class="flex flex-wrap justify-start gap-1 shadow-none">
     {#each Object.entries(contestTableProviderGroups) as [type, config]}
       <Button


### PR DESCRIPTION
close #2783
See #662

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved button group responsiveness with centered layout on smaller screens and left-aligned layout on larger screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->