### PR TITLE
chore: Rename qual round table

### DIFF
--- a/src/lib/utils/contest_table_provider.ts
+++ b/src/lib/utils/contest_table_provider.ts
@@ -895,7 +895,7 @@ export class JOIQualRoundFrom2006To2019Provider extends ContestTableProviderBase
 
   getMetadata(): ContestTableMetaData {
     return {
-      title: 'JOI 予選',
+      title: 'JOI 予選（旧形式）',
       abbreviationName: 'joiQualRoundFrom2006To2019',
     };
   }
@@ -1228,8 +1228,8 @@ export const prepareContestProviderPresets = () => {
       }).addProvider(new JOIFirstQualRoundProvider(ContestType.JOI)),
 
     JOISecondQualAndSemiFinalRound: () =>
-      new ContestTableProviderGroup(`JOI 二次予選・予選・本選`, {
-        buttonLabel: 'JOI 二次予選・予選・本選',
+      new ContestTableProviderGroup(`JOI 二次予選・予選（旧形式）・本選`, {
+        buttonLabel: 'JOI 二次予選・予選（旧形式）・本選',
         ariaLabel: 'Filter JOI Second Qual Round',
       }).addProviders(
         new JOISecondQualRound2020OnwardsProvider(ContestType.JOI),

--- a/src/test/lib/utils/contest_table_provider.test.ts
+++ b/src/test/lib/utils/contest_table_provider.test.ts
@@ -2323,7 +2323,7 @@ describe('ContestTableProviderBase and implementations', () => {
       const provider = new JOIQualRoundFrom2006To2019Provider(ContestType.JOI);
       const metadata = provider.getMetadata();
 
-      expect(metadata.title).toBe('JOI 予選');
+      expect(metadata.title).toBe('JOI 予選（旧形式）');
       expect(metadata.abbreviationName).toBe('joiQualRoundFrom2006To2019');
     });
 


### PR DESCRIPTION
テーブル名を「予選」から「予選（旧形式）」に変更しました。

ご確認よろしくお願いいたします。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated contest category and button labels to explicitly mark the JOI qualification rounds as the "old format" (improves clarity when browsing competitions).
* **Tests**
  * Updated expectations to match the new "old format" label so UI/test outputs remain consistent.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->