### PR TITLE
chore: Bump pnpm from 10.28 to 10.29.1 in package.json (#3148)

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "vercel": "50.13.2",
     "xss": "1.0.15"
   },
-  "packageManager": "pnpm@10.28.0",
+  "packageManager": "pnpm@10.29.1",
   "engines": {
     "node": "24.x"
   }


### PR DESCRIPTION
close #3148

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated package manager to pnpm version 10.29.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->