### PR TITLE
fix: Address lint errors after svelte-check and eslint pass

### DIFF
--- a/src/features/tasks/components/contest-table/TaskTable.svelte
+++ b/src/features/tasks/components/contest-table/TaskTable.svelte
@@ -66,7 +66,7 @@
   let contestTableMaps = $derived(prepareContestTablesMap(providers));
 
   function prepareContestTablesMap(providers: ContestTableProvider[]): Map<string, ProviderData> {
-    const map = new Map<string, ProviderData>();
+    const map = new SvelteMap<string, ProviderData>();
 
     for (const provider of providers) {
       const abbreviationName = provider.getMetadata().abbreviationName;
@@ -162,7 +162,7 @@
   });
 
   let taskIndicesMap = $derived.by(() => {
-    const indices = new Map<ContestTaskPairKey, number>();
+    const indices = new SvelteMap<ContestTaskPairKey, number>();
 
     taskResults.forEach((task, index) => {
       const key = createContestTaskPairKey(task.contest_id, task.task_id);

--- a/src/lib/components/AuthForm.svelte
+++ b/src/lib/components/AuthForm.svelte
@@ -224,6 +224,7 @@
 
       <div class="text-sm font-medium text-gray-500 dark:text-gray-300">
         {confirmationMessage}
+        <!-- eslint-disable-next-line svelte/no-navigation-without-resolve -->
         <a href={alternativeHref} class="text-primary-700 hover:underline dark:text-primary-500">
           {alternativePageName}
         </a>

--- a/src/routes/(admin)/workbooks/order/_components/KanbanBoard.svelte
+++ b/src/routes/(admin)/workbooks/order/_components/KanbanBoard.svelte
@@ -61,7 +61,7 @@
       selectedGrades,
     );
     // @ts-expect-error svelte-check TS2554: AppTypes declaration merging causes RouteId to resolve as string, requiring params. Runtime behavior is correct.
-    replaceState(resolve(updatedUrl.pathname) + updatedUrl.search, {});
+    replaceState(resolve(updatedUrl.pathname) + updatedUrl.search + updatedUrl.hash, $page.state);
   }
 
   let allItems = $state<Record<string, KanbanColumns>>(

--- a/src/routes/(admin)/workbooks/order/_components/KanbanBoard.svelte
+++ b/src/routes/(admin)/workbooks/order/_components/KanbanBoard.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { page } from '$app/stores';
   import { replaceState } from '$app/navigation';
+  import { resolve } from '$app/paths';
   import { untrack } from 'svelte';
 
   import { Toast } from 'flowbite-svelte';
@@ -59,7 +60,8 @@
       selectedSolutionCategories,
       selectedGrades,
     );
-    replaceState(updatedUrl, {});
+    // @ts-expect-error svelte-check TS2554: AppTypes declaration merging causes RouteId to resolve as string, requiring params. Runtime behavior is correct.
+    replaceState(resolve(updatedUrl.pathname) + updatedUrl.search, {});
   }
 
   let allItems = $state<Record<string, KanbanColumns>>(


### PR DESCRIPTION
close #2345

- TaskTable: restore SvelteMap for contestTableMaps and taskIndicesMap (svelte/prefer-svelte-reactivity requires SvelteMap in $state/$derived contexts)
- KanbanBoard: re-apply resolve() with path/search split to satisfy no-navigation-without-resolve
- AuthForm: add eslint-disable comment for alternativeHref (union type prevents resolve())

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * 内部のリアクティブマップ実装を最適化
  * URLハンドリングロジックを改善
  * コード品質と型安全性を強化

<!-- end of auto-generated comment: release notes by coderabbit.ai -->