### PR TITLE
fix: Consolidate resolve() arguments to satisfy eslint-plugin-svelte …

### DIFF
--- a/.claude/rules/sveltekit.md
+++ b/.claude/rules/sveltekit.md
@@ -32,9 +32,17 @@ const homeHref = resolve('/');
 
 **External links** — add `rel="noreferrer external"` instead of wrapping with `resolve()`.
 
-**Do not pass query strings to `resolve()`** — `resolve()` accepts route patterns only (e.g. `'/workbooks'`). A path like `'/workbooks?tab=foo'` is not a valid route pattern and causes a type error. Split path and search before passing: `resolve(url.pathname) + url.search`.
+**With query string or hash** — `svelte/no-navigation-without-resolve` (eslint-plugin-svelte 3.16.0+) requires the _entire_ first argument to be a direct `resolve()` call. Concatenating `resolve(path) + search` is now rejected. Pass path, search, and hash as a single concatenated string inside `resolve()`:
 
-**Do not apply `resolve()` to URLs derived from `$page.url`** — `$page.url` is the actual browser URL with the base path already applied. Wrapping a value derived from it with `resolve()` double-applies the base path. Pass the `URL` object directly to `replaceState` or extract `.pathname + .search` without `resolve()`.
+```typescript
+// Bad — rejected by eslint-plugin-svelte 3.16.0+
+goto(resolve(url.pathname) + url.search);
+replaceState(resolve(url.pathname) + url.search + url.hash, state);
+
+// Good
+goto(resolve(url.pathname + url.search));
+replaceState(resolve(url.pathname + url.search + url.hash), state);
+```
 
 ## Page Component Props
 

--- a/src/routes/(admin)/workbooks/order/_components/KanbanBoard.svelte
+++ b/src/routes/(admin)/workbooks/order/_components/KanbanBoard.svelte
@@ -61,7 +61,7 @@
       selectedGrades,
     );
     // @ts-expect-error svelte-check TS2554: AppTypes declaration merging causes RouteId to resolve as string, requiring params. Runtime behavior is correct.
-    replaceState(resolve(updatedUrl.pathname) + updatedUrl.search + updatedUrl.hash, $page.state);
+    replaceState(resolve(updatedUrl.pathname + updatedUrl.search + updatedUrl.hash), $page.state);
   }
 
   let allItems = $state<Record<string, KanbanColumns>>(

--- a/src/routes/users/edit/+page.svelte
+++ b/src/routes/users/edit/+page.svelte
@@ -22,10 +22,13 @@
       message_type: string;
       message: string;
     };
-    status?: string;
   }
 
-  let { data, status = $bindable('nothing') }: Props = $props();
+  let { data }: Props = $props();
+  // TODO: Restore when AtCoderUserValidationForm is re-enabled (svelte/valid-prop-names-in-kit-pages requires $bindable props to be declared in Props):
+  //   interface Props { ...; status?: string; }
+  //   let { data, status = $bindable('nothing') }: Props = $props();
+  // let status = $state('nothing');
 
   let role = data.role;
   let username = data.username;
@@ -35,12 +38,12 @@
   let message = data.message;
   let message_type = data.message_type;
 
-  if (data.is_validated) {
-    status = 'validated';
-  }
-  if (data.atcoder_username.length > 0 && data.atcoder_validationcode.length > 0) {
-    status = 'generated';
-  }
+  // if (data.is_validated) {
+  //   status = 'validated';
+  // }
+  // if (data.atcoder_username.length > 0 && data.atcoder_validationcode.length > 0) {
+  //   status = 'generated';
+  // }
 
   const isGeneralUser = (userRole: Roles, userName: string) => {
     return userRole === Roles.USER && userName !== 'guest';

--- a/src/routes/workbooks/+page.svelte
+++ b/src/routes/workbooks/+page.svelte
@@ -51,7 +51,7 @@
     if (saved) {
       const savedUrl = new URL(saved, window.location.origin);
       // @ts-expect-error svelte-check TS2554: AppTypes declaration merging causes RouteId to resolve as string, requiring params. Runtime behavior is correct.
-      goto(resolve(savedUrl.pathname) + savedUrl.search, { replaceState: true });
+      goto(resolve(savedUrl.pathname + savedUrl.search), { replaceState: true });
     }
   });
 


### PR DESCRIPTION
…3.16.0+

- KanbanBoard, workbooks: pass pathname+search+hash as single string inside resolve() (concatenating resolve(path) + search is now rejected by no-navigation-without-resolve)
- users/edit: comment out status state and assignments until AtCoderUserValidationForm is restored
- sveltekit.md: update resolve() rule with correct pattern for query string and hash

close #2345


src/routes/users/edit/+page.svelte の TODO: コメント は 別の PR で近日中に修正するものなので意図です。
レビューの対象外として。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * ナビゲーション設定ルールを更新しました。

* **Refactor**
  * URLパス解決のメカニズムを改善しました。
  * 不要なステータス管理機能を削除しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->