### PR TITLE
fix: Use task.id instead of task.task_id as key in TaskListForEdit

### DIFF
--- a/src/lib/components/TaskListForEdit.svelte
+++ b/src/lib/components/TaskListForEdit.svelte
@@ -62,7 +62,7 @@
           </TableBodyCell>
           <TableBodyCell>
             <form method="POST" action="?/create">
-              <Input size="md" type="hidden" name="contest_id" bind:value={importContest.id} />
+              <Input size="md" type="hidden" name="contest_id" value={importContest.id} />
 
               <Button type="submit">インポート</Button>
             </form>

--- a/src/lib/components/TaskListForEdit.svelte
+++ b/src/lib/components/TaskListForEdit.svelte
@@ -56,7 +56,7 @@
           </TableBodyCell>
 
           <TableBodyCell>
-            {#each importContest.tasks as importTask (importTask.task_id)}
+            {#each importContest.tasks as importTask (importTask.id)}
               <li>{importTask.title}</li>
             {/each}
           </TableBodyCell>


### PR DESCRIPTION
close #3441

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * タスク一覧の項目識別方法を調整し、レンダリング時の更新処理を改善しました。
  * フォーム入力値の処理方法を修正し、意図しない値の更新を防ぐようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->