### PR TITLE
fix: use unique temp_ prefix for unregistered tags to avoid duplicate each keys (#3509)

### DIFF
--- a/src/lib/components/TagListForEdit.svelte
+++ b/src/lib/components/TagListForEdit.svelte
@@ -59,7 +59,8 @@
           </Label>
         </TableBodyCell>
         <TableBodyCell>
-          {#if tag.id !== 'undefined'}
+          <!-- Note: temp_ prefix = not yet in DB; show edit link only for registered tags -->
+          {#if !tag.id.startsWith('temp_')}
             <a href={resolve('/(admin)/tags/[tag_id]', { tag_id: tag.id })}>編集</a>
           {:else}
             未登録

--- a/src/routes/(admin)/tasks/[task_id]/+page.server.ts
+++ b/src/routes/(admin)/tasks/[task_id]/+page.server.ts
@@ -31,7 +31,7 @@ export async function load({ locals, params, url }) {
     for (let i = 0; i < importTags.length; i++) {
       if (!tagMap.has(importTags[i])) {
         const tmpTag = {
-          id: 'undefined',
+          id: `temp_${importTags[i]}`, // Note: temp_ prefix = not yet in DB; used to distinguish from existing tags in the UI
           name: importTags[i],
           is_published: false,
           is_official: false,


### PR DESCRIPTION
close #3509

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * インポートされたタグのUIハンドリングを改善しました。データベースに未保存の一時的なタグは「未登録」と表示され、編集リンクは表示されなくなります。これにより、新規タグと既存タグの区別がより明確になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## スコープの対象外

- タグ機能の根本的な再設計