### PR TITLE
fix: rename EDPC・TDPC・NDPC・FPS 24 group label to xDPC・FPS 24

### DIFF
--- a/src/features/tasks/utils/contest-table/contest_table_provider_groups.test.ts
+++ b/src/features/tasks/utils/contest-table/contest_table_provider_groups.test.ts
@@ -229,10 +229,10 @@ describe('prepareContestProviderPresets', () => {
   test('expects to create DPs preset correctly', () => {
     const group = prepareContestProviderPresets().dps();
 
-    expect(group.getGroupName()).toBe('EDPC・TDPC・NDPC・FPS 24');
+    expect(group.getGroupName()).toBe('xDPC・FPS 24');
     expect(group.getMetadata()).toEqual({
-      buttonLabel: 'EDPC・TDPC・NDPC・FPS 24',
-      ariaLabel: 'EDPC, TDPC, NDPC and FPS 24 contests',
+      buttonLabel: 'xDPC・FPS 24',
+      ariaLabel: 'xDPC and FPS 24 contests',
     });
     expect(group.getSize()).toBe(4);
     expect(group.getProvider(ContestType.EDPC)).toBeInstanceOf(EDPCProvider);

--- a/src/features/tasks/utils/contest-table/contest_table_provider_groups.ts
+++ b/src/features/tasks/utils/contest-table/contest_table_provider_groups.ts
@@ -185,9 +185,9 @@ export const prepareContestProviderPresets = () => {
      * DP group (EDPC, TDPC, NDPC, and FPS 24)
      */
     dps: () =>
-      new ContestTableProviderGroup(`EDPC・TDPC・NDPC・FPS 24`, {
-        buttonLabel: 'EDPC・TDPC・NDPC・FPS 24',
-        ariaLabel: 'EDPC, TDPC, NDPC and FPS 24 contests',
+      new ContestTableProviderGroup(`xDPC・FPS 24`, {
+        buttonLabel: 'xDPC・FPS 24',
+        ariaLabel: 'xDPC and FPS 24 contests',
       }).addProviders(
         new EDPCProvider(ContestType.EDPC),
         new TDPCProvider(ContestType.TDPC),


### PR DESCRIPTION
close #3518

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **その他の更新**
  * コンテストグループの表示名および アクセシビリティテキストを更新しました。DP系コンテストグループの表示が「xDPC・FPS 24」に変更され、スクリーンリーダー用テキストが対応して更新されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->