### PR TITLE
[feat] 問題集の詳細ページで管理者と投票結果の差分を表すアイコンを表示する

### DIFF
--- a/src/features/votes/services/vote_statistics.test.ts
+++ b/src/features/votes/services/vote_statistics.test.ts
@@ -4,6 +4,7 @@ import { TaskGrade } from '@prisma/client';
 
 import {
   getVoteGradeStatistics,
+  getVoteGradeStatisticsForTaskIds,
   getAllTasksWithVoteInfo,
   getVoteCountersByTaskId,
   getVoteStatsByTaskId,
@@ -288,5 +289,47 @@ describe('getAllVoteCounters', () => {
 
     expect(result).toHaveLength(2);
     expect(prisma.votedGradeCounter.findMany).toHaveBeenCalledWith();
+  });
+});
+
+describe('getVoteGradeStatisticsForTaskIds', () => {
+  test('queries with a WHERE IN filter for the given taskIds', async () => {
+    mockVotedGradeStatisticsFindMany([]);
+
+    await getVoteGradeStatisticsForTaskIds(['abc001_a', 'abc002_a']);
+
+    expect(prisma.votedGradeStatistics.findMany).toHaveBeenCalledWith({
+      where: { taskId: { in: ['abc001_a', 'abc002_a'] } },
+    });
+  });
+
+  test('returns an empty Map when no matching statistics exist', async () => {
+    mockVotedGradeStatisticsFindMany([]);
+
+    const result = await getVoteGradeStatisticsForTaskIds(['abc001_a']);
+
+    expect(result.size).toBe(0);
+  });
+
+  test('maps each taskId to its statistics record', async () => {
+    const stat = makeStatisticsRecord({ taskId: 'abc001_a', grade: TaskGrade.Q5 });
+    mockVotedGradeStatisticsFindMany([stat]);
+
+    const result = await getVoteGradeStatisticsForTaskIds(['abc001_a']);
+
+    expect(result.get('abc001_a')?.grade).toBe(TaskGrade.Q5);
+  });
+
+  test('returns only statistics for the specified taskIds', async () => {
+    const records = [
+      makeStatisticsRecord({ taskId: 'abc001_a', grade: TaskGrade.Q5 }),
+      makeStatisticsRecord({ id: 'stats-abc002_a', taskId: 'abc002_a', grade: TaskGrade.D1 }),
+    ];
+    mockVotedGradeStatisticsFindMany(records);
+
+    const result = await getVoteGradeStatisticsForTaskIds(['abc001_a', 'abc002_a']);
+
+    expect(result.size).toBe(2);
+    expect(result.get('abc002_a')?.grade).toBe(TaskGrade.D1);
   });
 });

--- a/src/features/votes/services/vote_statistics.test.ts
+++ b/src/features/votes/services/vote_statistics.test.ts
@@ -293,6 +293,13 @@ describe('getAllVoteCounters', () => {
 });
 
 describe('getVoteGradeStatisticsForTaskIds', () => {
+  test('returns an empty Map without querying the DB when taskIds is empty', async () => {
+    const result = await getVoteGradeStatisticsForTaskIds([]);
+
+    expect(result.size).toBe(0);
+    expect(prisma.votedGradeStatistics.findMany).not.toHaveBeenCalled();
+  });
+
   test('queries with a WHERE IN filter for the given taskIds', async () => {
     mockVotedGradeStatisticsFindMany([]);
 

--- a/src/features/votes/services/vote_statistics.ts
+++ b/src/features/votes/services/vote_statistics.ts
@@ -27,6 +27,10 @@ export async function getVoteGradeStatistics(): Promise<Map<string, VotedGradeSt
 export async function getVoteGradeStatisticsForTaskIds(
   taskIds: string[],
 ): Promise<Map<string, VotedGradeStatistics>> {
+  if (taskIds.length === 0) {
+    return new Map();
+  }
+
   const stats = await prisma.votedGradeStatistics.findMany({
     where: { taskId: { in: taskIds } },
   });

--- a/src/features/votes/services/vote_statistics.ts
+++ b/src/features/votes/services/vote_statistics.ts
@@ -24,6 +24,15 @@ export async function getVoteGradeStatistics(): Promise<Map<string, VotedGradeSt
   return gradesMap;
 }
 
+export async function getVoteGradeStatisticsForTaskIds(
+  taskIds: string[],
+): Promise<Map<string, VotedGradeStatistics>> {
+  const stats = await prisma.votedGradeStatistics.findMany({
+    where: { taskId: { in: taskIds } },
+  });
+  return new Map(stats.map((s) => [s.taskId, s]));
+}
+
 export async function getAllTasksWithVoteInfo(): Promise<TaskWithVoteInfo[]> {
   const [allTasks, stats, counters] = await Promise.all([
     prisma.task.findMany({ orderBy: { task_id: 'desc' } }),

--- a/src/routes/workbooks/[slug]/+page.server.ts
+++ b/src/routes/workbooks/[slug]/+page.server.ts
@@ -6,7 +6,7 @@ import type { TaskResult } from '$lib/types/task';
 import * as taskResultsCrud from '$lib/services/task_results';
 import { getWorkbookWithAuthor } from '$features/workbooks/services/workbooks';
 import * as action from '$lib/actions/update_task_result';
-import { getVoteGradeStatistics } from '$features/votes/services/vote_statistics';
+import { getVoteGradeStatisticsForTaskIds } from '$features/votes/services/vote_statistics';
 
 import { isAdmin, canRead } from '$lib/utils/authorship';
 import { getLoggedInUser } from '$features/auth/services/session';
@@ -37,9 +37,10 @@ export async function load({ locals, params, url }) {
     error(FORBIDDEN, `問題集id: ${slug} にアクセスする権限がありません。`);
   }
 
+  const taskIds = workBook.workBookTasks.map((t) => t.taskId);
   const [taskResults, voteStatisticsMap] = await Promise.all([
     taskResultsCrud.getTaskResultsByTaskId(workBook.workBookTasks, loggedInUser?.id as string),
-    getVoteGradeStatistics(),
+    getVoteGradeStatisticsForTaskIds(taskIds),
   ]);
 
   return {

--- a/src/routes/workbooks/[slug]/+page.server.ts
+++ b/src/routes/workbooks/[slug]/+page.server.ts
@@ -6,6 +6,7 @@ import type { TaskResult } from '$lib/types/task';
 import * as taskResultsCrud from '$lib/services/task_results';
 import { getWorkbookWithAuthor } from '$features/workbooks/services/workbooks';
 import * as action from '$lib/actions/update_task_result';
+import { getVoteGradeStatistics } from '$features/votes/services/vote_statistics';
 
 import { isAdmin, canRead } from '$lib/utils/authorship';
 import { getLoggedInUser } from '$features/auth/services/session';
@@ -36,16 +37,17 @@ export async function load({ locals, params, url }) {
     error(FORBIDDEN, `問題集id: ${slug} にアクセスする権限がありません。`);
   }
 
-  const taskResults: Map<string, TaskResult> = await taskResultsCrud.getTaskResultsByTaskId(
-    workBook.workBookTasks,
-    loggedInUser?.id as string,
-  );
+  const [taskResults, voteStatisticsMap] = await Promise.all([
+    taskResultsCrud.getTaskResultsByTaskId(workBook.workBookTasks, loggedInUser?.id as string),
+    getVoteGradeStatistics(),
+  ]);
 
   return {
     isLoggedIn: loggedInUser !== null,
     loggedInAsAdmin: loggedInAsAdmin,
     ...workbookWithAuthor,
     taskResults: taskResults,
+    voteStatisticsMap: voteStatisticsMap,
   };
 }
 

--- a/src/routes/workbooks/[slug]/+page.server.ts
+++ b/src/routes/workbooks/[slug]/+page.server.ts
@@ -1,7 +1,6 @@
 import { error, type Actions } from '@sveltejs/kit';
 
 import { Roles } from '$lib/types/user';
-import type { TaskResult } from '$lib/types/task';
 
 import * as taskResultsCrud from '$lib/services/task_results';
 import { getWorkbookWithAuthor } from '$features/workbooks/services/workbooks';

--- a/src/routes/workbooks/[slug]/+page.svelte
+++ b/src/routes/workbooks/[slug]/+page.svelte
@@ -18,6 +18,7 @@
   import ExternalLinkWrapper from '$lib/components/ExternalLinkWrapper.svelte';
   import PublicationStatusLabel from '$features/workbooks/components/shared/PublicationStatusLabel.svelte';
   import CommentAndHint from '$features/workbooks/components/detail/CommentAndHint.svelte';
+  import RelativeEvaluationBadge from '$features/votes/components/RelativeEvaluationBadge.svelte';
 
   import { getBackgroundColorFrom } from '$lib/services/submission_status';
 
@@ -33,6 +34,7 @@
   let workBook = data.workBook;
   let workBookTasks: WorkBookTaskBase[] = $state([]);
   let taskResults: Map<string, TaskResult> = $derived(data.taskResults);
+  let voteStatisticsMap = $derived(data.voteStatisticsMap);
 
   let isLoggedIn = data.isLoggedIn;
 
@@ -157,6 +159,8 @@
         </TableHead>
         <TableBody class="divide-y divide-gray-200 dark:divide-gray-700">
           {#each workBookTasks as workBookTask (workBookTask.taskId)}
+            {@const taskGrade = getTaskGrade(workBookTask.taskId)}
+            {@const statsEntry = voteStatisticsMap?.get(workBookTask.taskId)}
             <TableBodyRow
               id={getUniqueIdUsing(workBookTask.taskId)}
               class={getBackgroundColorFrom(getTaskResult(workBookTask.taskId).status_name)}
@@ -164,7 +168,16 @@
               <!-- 問題のグレード -->
               <TableBodyCell class="justify-center w-16 px-0.5 xs:px-3">
                 <div class="flex items-center justify-center min-w-[54px] max-w-[54px]">
-                  <GradeLabel taskGrade={getTaskGrade(workBookTask.taskId)} />
+                  <div class="relative">
+                    <GradeLabel {taskGrade} />
+                    {#if taskGrade !== TaskGrade.PENDING && statsEntry}
+                      <RelativeEvaluationBadge
+                        officialGrade={taskGrade}
+                        medianGrade={statsEntry.grade}
+                        badgeId="rel-eval-{getUniqueIdUsing(workBookTask.taskId)}"
+                      />
+                    {/if}
+                  </div>
                 </div>
               </TableBodyCell>
 


### PR DESCRIPTION
## Summary

- Closes #3582
- 問題集詳細ページのグレード列に `RelativeEvaluationBadge` を追加し、管理者確定グレードと投票中央値の差分アイコンを表示する
- 投票統計 (`getVoteGradeStatistics`) をタスク結果と並列取得してページに渡す

## Changes

- `src/routes/workbooks/[slug]/+page.server.ts`: `getVoteGradeStatistics()` を `taskResultsCrud.getTaskResultsByTaskId()` と `Promise.all` で並列取得し、`voteStatisticsMap` を返す
- `src/routes/workbooks/[slug]/+page.svelte`: `RelativeEvaluationBadge` をインポートし、グレードアイコンの右上に差分バッジを表示（確定グレードかつ投票中央値がある場合のみ）

## Test plan

- [ ] 確定グレードが付いたタスクを含む問題集の詳細ページで、グレードアイコン右上に差分バッジ（`++`/`+`/`±0`/`-`/`--`）が表示されることを確認
- [ ] `PENDING` グレードのタスクにはバッジが表示されないことを確認
- [ ] 投票中央値がないタスク（未投票）にはバッジが表示されないことを確認
- [ ] `pnpm format && pnpm check && pnpm test:unit` がすべてパスすることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 各問題行に投票統計に基づく相対評価バッジを表示するようになりました。グレード統計が利用可能な場合、バッジが表示されます。
* **パフォーマンス**
  * 問題一覧のデータ取得が並列化され、読み込みがより速くなりました。
* **テスト**
  * 投票統計取得ロジックの挙動を検証するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->