### PR TITLE
feat(contest): add cf16-final and dwango2016-prelims contest mappings

### DIFF
--- a/src/lib/utils/contest.ts
+++ b/src/lib/utils/contest.ts
@@ -156,6 +156,7 @@ const arcLikePrefixes = new Set(getContestPrefixes(ARC_LIKE));
 const AGC_LIKE: ContestPrefix = {
   'code-festival-2016-qual': 'CODE FESTIVAL 2016 qual',
   'code-festival-2017-qual': 'CODE FESTIVAL 2017 qual',
+  'cf16-final': 'CODE FESTIVAL 2016 final',
   'cf17-final': 'CODE FESTIVAL 2017 final',
 } as const;
 const agcLikePrefixes = getContestPrefixes(AGC_LIKE);
@@ -225,6 +226,7 @@ const ATCODER_OTHERS: ContestPrefix = {
   'code-thanks-festival': 'CODE THANKS FESTIVAL',
   donuts: 'Donutsプロコンチャレンジ',
   indeednow: 'Indeedなう',
+  'dwango2016-prelims': '第2回 ドワンゴからの挑戦状 予選',
   'dwacon2017-prelims': '第3回 ドワンゴからの挑戦状 予選',
   'mujin-pc-2016': 'Mujin Programming Challenge 2016',
   'mujin-pc-2018': 'Mujin Programming Challenge 2018',

--- a/src/test/lib/utils/test_cases/contest_name_labels.ts
+++ b/src/test/lib/utils/test_cases/contest_name_labels.ts
@@ -56,6 +56,10 @@ export const atCoderOthers = [
     contestId: 's8pc-4',
     expected: 'square869120Contest #4',
   }),
+  createTestCaseForContestNameLabel('第2回 ドワンゴからの挑戦状 予選')({
+    contestId: 'dwango2016-prelims',
+    expected: '第2回 ドワンゴからの挑戦状 予選',
+  }),
 ];
 
 export const mathAndAlgorithm = [

--- a/src/test/lib/utils/test_cases/contest_type.ts
+++ b/src/test/lib/utils/test_cases/contest_type.ts
@@ -340,6 +340,10 @@ export const agcLike = [
     contestId: 'code-festival-2017-qualc',
     expected: ContestType.AGC_LIKE,
   }),
+  createTestCaseForContestType('CODE FESTIVAL 2016 final')({
+    contestId: 'cf16-final',
+    expected: ContestType.AGC_LIKE,
+  }),
   createTestCaseForContestType('CODE FESTIVAL 2017 final')({
     contestId: 'cf17-final',
     expected: ContestType.AGC_LIKE,
@@ -474,6 +478,10 @@ export const atCoderOthers = [
   }),
   createTestCaseForContestType('IndeedNow Qual B')({
     contestId: 'indeednow-qualb',
+    expected: ContestType.OTHERS,
+  }),
+  createTestCaseForContestType('第2回 ドワンゴからの挑戦状 予選')({
+    contestId: 'dwango2016-prelims',
     expected: ContestType.OTHERS,
   }),
   createTestCaseForContestType('第3回 ドワンゴからの挑戦状 予選')({


### PR DESCRIPTION
close #3634

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 追加のコンテストに対応し、コンテスト種別の分類とラベル表示を拡張しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->