### PR TITLE
暫定グレード表示の最小票数を3→1に変更

### DIFF
--- a/src/features/votes/constants/statistics.ts
+++ b/src/features/votes/constants/statistics.ts
@@ -1,5 +1,11 @@
 /**
- * Minimum number of votes required to compute and store the median grade.
- * Below this threshold the sample size is too small to be meaningful.
+ * Minimum votes to compute and store the median for a confirmed-grade task.
+ * Used for the relative evaluation badge (++/+/±0/-/--).
  */
 export const MIN_VOTES_FOR_STATISTICS = 3;
+
+/**
+ * Minimum votes to compute and store the median for a PENDING task.
+ * Used for the provisional grade display (暫定グレード).
+ */
+export const MIN_VOTES_FOR_PROVISIONAL_GRADE = 1;

--- a/src/features/votes/services/vote_grade.test.ts
+++ b/src/features/votes/services/vote_grade.test.ts
@@ -18,6 +18,9 @@ vi.mock('$lib/server/database', () => ({
     votedGradeStatistics: {
       upsert: vi.fn(),
     },
+    task: {
+      findUnique: vi.fn(),
+    },
     $transaction: vi.fn(),
   },
 }));
@@ -48,12 +51,15 @@ function setupTransaction() {
     voteGrade: { findUnique: vi.fn(), upsert: vi.fn() },
     votedGradeCounter: { updateMany: vi.fn(), upsert: vi.fn(), findMany: vi.fn() },
     votedGradeStatistics: { upsert: vi.fn() },
+    task: { findUnique: vi.fn() },
   };
   vi.mocked(prisma.$transaction).mockImplementation(async (callback: unknown) =>
     (callback as (tx: typeof mockTx) => Promise<unknown>)(mockTx),
   );
   return mockTx;
 }
+
+type MockTx = ReturnType<typeof setupTransaction>;
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -117,6 +123,7 @@ describe('upsertVoteGradeTables', () => {
       { grade: TaskGrade.Q5, count: 1 },
       { grade: TaskGrade.Q4, count: 0 },
     ]);
+    tx.task.findUnique.mockResolvedValue({ grade: TaskGrade.Q3 });
 
     await upsertVoteGradeTables('user-1', 'abc001_a', TaskGrade.Q5);
 
@@ -134,7 +141,7 @@ describe('upsertVoteGradeTables', () => {
         update: { count: { increment: 1 } },
       }),
     );
-    // Total = 1 vote (Q5:1 + Q4:0), below MIN_VOTES_FOR_STATISTICS — statistics must not be updated
+    // Total = 1 vote (Q5:1 + Q4:0), below MIN_VOTES_FOR_STATISTICS (3) for non-PENDING task — statistics must not be updated
     expect(tx.votedGradeStatistics.upsert).not.toHaveBeenCalled();
   });
 
@@ -144,6 +151,7 @@ describe('upsertVoteGradeTables', () => {
     tx.voteGrade.upsert.mockResolvedValue({});
     tx.votedGradeCounter.upsert.mockResolvedValue({});
     tx.votedGradeCounter.findMany.mockResolvedValue([{ grade: TaskGrade.Q5, count: 1 }]);
+    tx.task.findUnique.mockResolvedValue({ grade: TaskGrade.Q3 });
 
     await upsertVoteGradeTables('user-1', 'abc001_a', TaskGrade.Q5);
 
@@ -159,17 +167,18 @@ describe('upsertVoteGradeTables', () => {
         update: { count: { increment: 1 } },
       }),
     );
-    // Total = 1 vote (Q5:1), below MIN_VOTES_FOR_STATISTICS — statistics must not be updated
+    // Total = 1 vote (Q5:1), below MIN_VOTES_FOR_STATISTICS (3) for non-PENDING task — statistics must not be updated
     expect(tx.votedGradeStatistics.upsert).not.toHaveBeenCalled();
   });
 
-  test('upserts VotedGradeStatistics when total votes reaches 3', async () => {
+  test('upserts VotedGradeStatistics when total votes reaches 3 for non-PENDING task', async () => {
     const tx = setupTransaction();
     tx.voteGrade.findUnique.mockResolvedValue(null);
     tx.voteGrade.upsert.mockResolvedValue({});
     tx.votedGradeCounter.upsert.mockResolvedValue({});
     // 3 votes all on Q5 → median = Q5
     tx.votedGradeCounter.findMany.mockResolvedValue([{ grade: TaskGrade.Q5, count: 3 }]);
+    tx.task.findUnique.mockResolvedValue({ grade: TaskGrade.Q3 });
     tx.votedGradeStatistics.upsert.mockResolvedValue({});
 
     await upsertVoteGradeTables('user-1', 'abc001_a', TaskGrade.Q5);
@@ -182,15 +191,35 @@ describe('upsertVoteGradeTables', () => {
     );
   });
 
-  test('does not upsert VotedGradeStatistics when total votes is below 3', async () => {
+  test('does not upsert VotedGradeStatistics when total votes is below 3 for non-PENDING task', async () => {
     const tx = setupTransaction();
     tx.voteGrade.findUnique.mockResolvedValue(null);
     tx.voteGrade.upsert.mockResolvedValue({});
     tx.votedGradeCounter.upsert.mockResolvedValue({});
     tx.votedGradeCounter.findMany.mockResolvedValue([{ grade: TaskGrade.Q5, count: 2 }]);
+    tx.task.findUnique.mockResolvedValue({ grade: TaskGrade.Q3 });
 
     await upsertVoteGradeTables('user-1', 'abc001_a', TaskGrade.Q5);
 
     expect(tx.votedGradeStatistics.upsert).not.toHaveBeenCalled();
+  });
+
+  test('upserts VotedGradeStatistics after 1 vote for PENDING task', async () => {
+    const tx = setupTransaction();
+    tx.voteGrade.findUnique.mockResolvedValue(null);
+    tx.voteGrade.upsert.mockResolvedValue({});
+    tx.votedGradeCounter.upsert.mockResolvedValue({});
+    tx.votedGradeCounter.findMany.mockResolvedValue([{ grade: TaskGrade.Q5, count: 1 }]);
+    tx.task.findUnique.mockResolvedValue({ grade: TaskGrade.PENDING });
+    tx.votedGradeStatistics.upsert.mockResolvedValue({});
+
+    await upsertVoteGradeTables('user-1', 'abc001_a', TaskGrade.Q5);
+
+    expect(tx.votedGradeStatistics.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { taskId: 'abc001_a' },
+        update: { grade: TaskGrade.Q5 },
+      }),
+    );
   });
 });

--- a/src/features/votes/services/vote_grade.ts
+++ b/src/features/votes/services/vote_grade.ts
@@ -3,7 +3,10 @@ import { TaskGrade } from '@prisma/client';
 import { sha256 } from '$lib/utils/hash';
 import type { VoteGradeResult } from '$features/votes/types/vote_result';
 import { computeMedianGrade } from '$features/votes/utils/median';
-import { MIN_VOTES_FOR_STATISTICS } from '$features/votes/constants/statistics';
+import {
+  MIN_VOTES_FOR_STATISTICS,
+  MIN_VOTES_FOR_PROVISIONAL_GRADE,
+} from '$features/votes/constants/statistics';
 
 export async function getVoteGrade(userId: string, taskId: string): Promise<VoteGradeResult> {
   const voteRecord = await prisma.voteGrade.findUnique({
@@ -51,11 +54,14 @@ export async function upsertVoteGradeTables(
     });
 
     const total = latestCounters.reduce((sum, counter) => sum + counter.count, 0);
-    if (total < MIN_VOTES_FOR_STATISTICS) {
+    const taskRecord = await tx.task.findUnique({ where: { task_id: taskId }, select: { grade: true } });
+    const minVotes =
+      taskRecord?.grade === TaskGrade.PENDING ? MIN_VOTES_FOR_PROVISIONAL_GRADE : MIN_VOTES_FOR_STATISTICS;
+    if (total < minVotes) {
       return;
     }
 
-    await updateVoteStatistics(tx, taskId, latestCounters);
+    await updateVoteStatistics(tx, taskId, latestCounters, minVotes);
   });
   return { success: true };
 }
@@ -118,8 +124,9 @@ async function updateVoteStatistics(
   tx: TxClient,
   taskId: string,
   counters: GradeCounter[],
+  minVotes: number,
 ): Promise<void> {
-  const medianGrade = computeMedianGrade(counters);
+  const medianGrade = computeMedianGrade(counters, minVotes);
   if (medianGrade === null) {
     return;
   }

--- a/src/routes/votes/+page.svelte
+++ b/src/routes/votes/+page.svelte
@@ -18,6 +18,7 @@
   import RelativeEvaluationBadge from '$features/votes/components/RelativeEvaluationBadge.svelte';
 
   import { TaskGrade } from '$lib/types/task';
+  import { MIN_VOTES_FOR_PROVISIONAL_GRADE } from '$features/votes/constants/statistics';
 
   import { getContestNameLabel } from '$lib/utils/contest';
   import { getTaskUrl, compareByContestIdAndTaskId } from '$lib/utils/task';
@@ -75,7 +76,7 @@
                       <FlaskConical class="w-4 h-4" aria-hidden="true" />
                     </span>
                     <Tooltip triggeredBy="#flask-{task.task_id}" placement="top">
-                      3票以上集まると中央値が暫定グレードとして一覧表に反映されます。
+                      {MIN_VOTES_FOR_PROVISIONAL_GRADE}票以上集まると中央値が暫定グレードとして一覧表に反映されます。
                     </Tooltip>
                   {/if}
 

--- a/src/routes/votes/[slug]/+page.svelte
+++ b/src/routes/votes/[slug]/+page.svelte
@@ -17,7 +17,7 @@
 
   import VoteDonutChart from '$features/votes/components/VoteDonutChart.svelte';
   import { qGrades, dGrades } from '$features/votes/utils/grade_options';
-  import { MIN_VOTES_FOR_STATISTICS } from '$features/votes/constants/statistics';
+  import { MIN_VOTES_FOR_PROVISIONAL_GRADE } from '$features/votes/constants/statistics';
 
   import { EDIT_PROFILE_PAGE } from '$lib/constants/navbar-links';
   import { buildLoginPath } from '$features/auth/utils/login';
@@ -53,7 +53,7 @@
         <FlaskConical class="w-5 h-5" />
       </span>
       <Tooltip triggeredBy="#flask-icon" placement="bottom">
-        {MIN_VOTES_FOR_STATISTICS}票以上集まると中央値が暫定グレードとして一覧表に反映されます。
+        {MIN_VOTES_FOR_PROVISIONAL_GRADE}票以上集まると中央値が暫定グレードとして一覧表に反映されます。
       </Tooltip>
     {/if}
     <div class="relative inline-block">


### PR DESCRIPTION
close #3648

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * タスク状態に応じた投票統計の判定基準を改善しました。
  * 投票の暫定グレード表示に関する説明文を更新し、正確な投票数閾値が表示されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->