### PR TITLE
chore: add @vercel/* to minimumReleaseAge exclusion and renovate immediate update list

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -27,6 +27,7 @@ minimumReleaseAgeExclude:
   - tsx
   # Vercel: To use in a CI/CD environment
   - vercel
+  - '@vercel/*'
 
 # Prevent transitive dependencies from Git/Tarball sources (enhanced security)
 blockExoticSubdeps: true

--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,7 @@
   "rangeStrategy": "increase",
   "packageRules": [
     {
-      "matchPackageNames": ["prisma", "@prisma/client", "tsx", "vercel"],
+      "matchPackageNames": ["prisma", "@prisma/client", "tsx", "vercel", "@vercel/*"],
       "minimumReleaseAge": "0 days"
     }
   ]


### PR DESCRIPTION
close #3797 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Vercel 関連の依存関係が、リリース経過時間の制限対象から外れるようになりました。
  * これにより、`@vercel/*` を含む関連パッケージにも既存の依存関係ルールが適用されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->