### PR TITLE
chore: move detail link to top of vote dropdown (#3795)

### DIFF
--- a/src/features/votes/components/VotableGrade.svelte
+++ b/src/features/votes/components/VotableGrade.svelte
@@ -231,6 +231,10 @@
     simple
     class="h-48 w-44 z-50 border border-gray-200 dark:border-gray-100 overflow-y-auto"
   >
+    <DropdownItem href={resolve('/votes/[slug]', { slug: taskResult.task_id })} class="rounded-md"
+      >詳細</DropdownItem
+    >
+    <DropdownDivider />
     {#each nonPendingGrades as grade (grade)}
       <DropdownItem onclick={() => handleClick(grade)} class="rounded-md">
         <div
@@ -252,10 +256,6 @@
         </div>
       </DropdownItem>
     {/each}
-    <DropdownDivider />
-    <DropdownItem href={resolve('/votes/[slug]', { slug: taskResult.task_id })} class="rounded-md"
-      >詳細</DropdownItem
-    >
   </Dropdown>
 {:else if isLoggedIn}
   <!-- Logged in but not AtCoder-verified: prompt user to complete verification -->


### PR DESCRIPTION
## Summary

- `VotableGrade.svelte` の投票ドロップダウンで、末尾にあった「詳細」リンクをグレード一覧の先頭に移動

## Before / After

**Before:** グレード一覧 (Q11〜D6) → 区切り線 → 詳細（スクロールしないと見えない）

**After:** 詳細 → 区切り線 → グレード一覧 (Q11〜D6)

## Test plan

- [x] 問題一覧のグレードアイコンをクリックしてドロップダウンを開き、「詳細」リンクが最上部に表示されることを確認
- [x] 「詳細」リンクをクリックして `/votes/[task_id]` ページへ遷移することを確認

Closes #3795

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EGhZMRXzv7YDEgpo9GVxAn

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI改善**
  * 投票グレードのドロップダウンで、「詳細」リンクの表示位置を見直しました。
  * グレード一覧の前に配置され、より見つけやすくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->