### PR TITLE
feat(aoj): add 3 university contest tasks (UAPC2017, RUPC2025, HUPC2018)

### DIFF
--- a/prisma/tasks.ts
+++ b/prisma/tasks.ts
@@ -16734,6 +16734,13 @@ export const tasks = [
     title: '1566. Movie',
   },
   {
+    id: '3022',
+    contest_id: 'AOJ-UAPC2017-in-ACPC2017-day2',
+    problem_index: '3022',
+    name: 'Cluster Network',
+    title: '3022. Cluster Network',
+  },
+  {
     id: '3047',
     contest_id: 'AOJ-UAPC2018-in-ACPC2018-day2',
     problem_index: '3047',
@@ -16783,11 +16790,25 @@ export const tasks = [
     title: '2943. Illumination',
   },
   {
+    id: '3426',
+    contest_id: 'AOJ-RUPC2025-in-ACPC2025-day1',
+    problem_index: '3426',
+    name: 'Nailed',
+    title: '3426. Nailed',
+  },
+  {
     id: '2581',
     contest_id: 'AOJ-HUPC2014-in-RUPC2014-day3',
     problem_index: '2581',
     name: 'Derangement',
     title: '2581. Derangement',
+  },
+  {
+    id: '2893',
+    contest_id: 'AOJ-HUPC2018-in-ACPC2018-day3',
+    problem_index: '2893',
+    name: 'Balanced Edge Deletion',
+    title: '2893. Balanced Edge Deletion',
   },
   {
     id: '2872',

--- a/src/test/lib/utils/test_cases/contest_name_and_task_index.ts
+++ b/src/test/lib/utils/test_cases/contest_name_and_task_index.ts
@@ -931,6 +931,21 @@ const AOJ_UNIVERSITY_TEST_DATA = [
     taskTableIndex: '1566',
     expected: 'AOJ 1566（ACPC 2015 in ACPC 2015 Day2）',
   },
+  {
+    contestId: 'AOJ-UAPC2017-in-ACPC2017-day2',
+    taskTableIndex: '3022',
+    expected: 'AOJ 3022（ACPC 2017 in ACPC 2017 Day2）',
+  },
+  {
+    contestId: 'AOJ-RUPC2025-in-ACPC2025-day1',
+    taskTableIndex: '3426',
+    expected: 'AOJ 3426（RUPC 2025 in ACPC 2025 Day1）',
+  },
+  {
+    contestId: 'AOJ-HUPC2018-in-ACPC2018-day3',
+    taskTableIndex: '2893',
+    expected: 'AOJ 2893（HUPC 2018 in ACPC 2018 Day3）',
+  },
 ];
 
 export const aojUniversity = AOJ_UNIVERSITY_TEST_DATA.map(

--- a/src/test/lib/utils/test_cases/contest_name_labels.ts
+++ b/src/test/lib/utils/test_cases/contest_name_labels.ts
@@ -222,4 +222,16 @@ export const aojUniversity = [
     contestId: 'AOJ-UAPC2015-in-ACPC2015-day2',
     expected: '（ACPC 2015 in ACPC 2015 Day2）',
   }),
+  createTestCaseForContestNameLabel('AOJ, UAPC 2017 in ACPC 2017 Day2')({
+    contestId: 'AOJ-UAPC2017-in-ACPC2017-day2',
+    expected: '（ACPC 2017 in ACPC 2017 Day2）',
+  }),
+  createTestCaseForContestNameLabel('AOJ, RUPC 2025 in ACPC 2025 Day1')({
+    contestId: 'AOJ-RUPC2025-in-ACPC2025-day1',
+    expected: '（RUPC 2025 in ACPC 2025 Day1）',
+  }),
+  createTestCaseForContestNameLabel('AOJ, HUPC 2018 in ACPC 2018 Day3')({
+    contestId: 'AOJ-HUPC2018-in-ACPC2018-day3',
+    expected: '（HUPC 2018 in ACPC 2018 Day3）',
+  }),
 ];

--- a/src/test/lib/utils/test_cases/contest_type.ts
+++ b/src/test/lib/utils/test_cases/contest_type.ts
@@ -715,9 +715,12 @@ export const aojIcpc = aojIcpcContestData.map(({ name, contestId }) =>
 );
 
 const aojUniversityContestData = [
+  { name: 'AOJ, RUPC 2025 in ACPC 2025 Day1', contestId: 'AOJ-RUPC2025-in-ACPC2025-day1' },
   { name: 'AOJ, RUPC 2018 in ACPC 2018 Day1', contestId: 'AOJ-RUPC2018-in-ACPC2018-day1' },
   { name: 'AOJ, HUPC 2020 in HUPC 2020 Day1', contestId: 'AOJ-HUPC2020-in-HUPC2020-day1' },
+  { name: 'AOJ, HUPC 2018 in ACPC 2018 Day3', contestId: 'AOJ-HUPC2018-in-ACPC2018-day3' },
   { name: 'AOJ, UAPC 2019 in RUPC 2019 Day2', contestId: 'AOJ-UAPC2019-in-RUPC2019-day2' },
+  { name: 'AOJ, UAPC 2017 in ACPC 2017 Day2', contestId: 'AOJ-UAPC2017-in-ACPC2017-day2' },
   { name: 'AOJ, UAPC 2003', contestId: 'AOJ-UAPC2003' },
   { name: 'AOJ, UAPC 2011 Summer', contestId: 'AOJ-UAPC2011-summer' },
   { name: 'AOJ, UAPC 2012 Day1', contestId: 'AOJ-UAPC2012-day1' },


### PR DESCRIPTION
close #3930

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * AOJの以下の3問を追加しました。
    * UAPC2017「Cluster Network」
    * RUPC2025「Nailed」
    * HUPC2018「Balanced Edge Deletion」

* **テスト**
  * 追加したコンテストの名称、ラベル、種別に関するテストケースを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->