### PR TITLE
feat(aoj): add university contest tasks and test cases

### DIFF
--- a/prisma/tasks.ts
+++ b/prisma/tasks.ts
@@ -16720,6 +16720,13 @@ export const tasks = [
     title: '2349. World Trip',
   },
   {
+    id: '1088',
+    contest_id: 'AOJ-UAPC2012-day1',
+    problem_index: '1088',
+    name: 'School Excursion',
+    title: '1088. School Excursion',
+  },
+  {
     id: '1532',
     contest_id: 'AOJ-UAPC2014-in-RUPC2014-day2',
     problem_index: '1532',
@@ -16739,6 +16746,13 @@ export const tasks = [
     problem_index: '3022',
     name: 'Cluster Network',
     title: '3022. Cluster Network',
+  },
+  {
+    id: '3032',
+    contest_id: 'AOJ-UAPC2018-in-RUPC2018-day2',
+    problem_index: '3032',
+    name: 'Combine Two Elements',
+    title: '3032. Combine Two Elements',
   },
   {
     id: '3047',
@@ -16769,6 +16783,13 @@ export const tasks = [
     title: '2520. Bicycle',
   },
   {
+    id: '2835',
+    contest_id: 'AOJ-RUPC2017-in-ACPC2017-day1',
+    problem_index: '2835',
+    name: 'Protect from the enemy attack',
+    title: '2835. Protect from the enemy attack',
+  },
+  {
     id: '2880',
     contest_id: 'AOJ-RUPC2018-in-RUPC2018-day1',
     problem_index: '2880',
@@ -16788,6 +16809,13 @@ export const tasks = [
     problem_index: '2943',
     name: 'Illumination',
     title: '2943. Illumination',
+  },
+  {
+    id: '3417',
+    contest_id: 'AOJ-RUPC2025-in-ACPC2025-day1',
+    problem_index: '3417',
+    name: 'Sugar Water with Subarray',
+    title: '3417. Sugar Water with Subarray',
   },
   {
     id: '3426',
@@ -16816,6 +16844,13 @@ export const tasks = [
     problem_index: '2872',
     name: 'Ebi-chan Lengthens Shortest Paths',
     title: '2872. Ebi-chan Lengthens Shortest Paths',
+  },
+  {
+    id: '2959',
+    contest_id: 'AOJ-HUPC2019-in-HUPC2019-day2',
+    problem_index: '2959',
+    name: 'Revenge of UMG',
+    title: '2959. Revenge of UMG',
   },
   {
     id: '3168',
@@ -16851,5 +16886,19 @@ export const tasks = [
     problem_index: '2496',
     name: '1',
     title: '2496. 1',
+  },
+  {
+    id: '3215',
+    contest_id: 'AOJ-OUPC2020',
+    problem_index: '3215',
+    name: 'Construction Set',
+    title: '3215. Construction Set',
+  },
+  {
+    id: '3412',
+    contest_id: 'AOJ-OUPC2024-day1',
+    problem_index: '3412',
+    name: 'Ikomiki String',
+    title: '3412. Ikomiki String',
   },
 ];

--- a/src/test/lib/utils/test_cases/contest_name_and_task_index.ts
+++ b/src/test/lib/utils/test_cases/contest_name_and_task_index.ts
@@ -946,6 +946,27 @@ const AOJ_UNIVERSITY_TEST_DATA = [
     taskTableIndex: '2893',
     expected: 'AOJ 2893（HUPC 2018 in ACPC 2018 Day3）',
   },
+  {
+    contestId: 'AOJ-UAPC2018-in-RUPC2018-day2',
+    taskTableIndex: '3032',
+    expected: 'AOJ 3032（ACPC 2018 in RUPC 2018 Day2）',
+  },
+  {
+    contestId: 'AOJ-RUPC2017-in-ACPC2017-day1',
+    taskTableIndex: '2835',
+    expected: 'AOJ 2835（RUPC 2017 in ACPC 2017 Day1）',
+  },
+  {
+    contestId: 'AOJ-HUPC2019-in-HUPC2019-day2',
+    taskTableIndex: '2959',
+    expected: 'AOJ 2959（HUPC 2019 in HUPC 2019 Day2）',
+  },
+  { contestId: 'AOJ-OUPC2020', taskTableIndex: '3215', expected: 'AOJ 3215（OUPC 2020）' },
+  {
+    contestId: 'AOJ-OUPC2024-day1',
+    taskTableIndex: '3412',
+    expected: 'AOJ 3412（OUPC 2024 Day1）',
+  },
 ];
 
 export const aojUniversity = AOJ_UNIVERSITY_TEST_DATA.map(

--- a/src/test/lib/utils/test_cases/contest_name_labels.ts
+++ b/src/test/lib/utils/test_cases/contest_name_labels.ts
@@ -234,4 +234,24 @@ export const aojUniversity = [
     contestId: 'AOJ-HUPC2018-in-ACPC2018-day3',
     expected: '（HUPC 2018 in ACPC 2018 Day3）',
   }),
+  createTestCaseForContestNameLabel('AOJ, UAPC 2018 in RUPC 2018 Day2')({
+    contestId: 'AOJ-UAPC2018-in-RUPC2018-day2',
+    expected: '（ACPC 2018 in RUPC 2018 Day2）',
+  }),
+  createTestCaseForContestNameLabel('AOJ, RUPC 2017 in ACPC 2017 Day1')({
+    contestId: 'AOJ-RUPC2017-in-ACPC2017-day1',
+    expected: '（RUPC 2017 in ACPC 2017 Day1）',
+  }),
+  createTestCaseForContestNameLabel('AOJ, HUPC 2019 in HUPC 2019 Day2')({
+    contestId: 'AOJ-HUPC2019-in-HUPC2019-day2',
+    expected: '（HUPC 2019 in HUPC 2019 Day2）',
+  }),
+  createTestCaseForContestNameLabel('AOJ, OUPC 2020')({
+    contestId: 'AOJ-OUPC2020',
+    expected: '（OUPC 2020）',
+  }),
+  createTestCaseForContestNameLabel('AOJ, OUPC 2024 Day1')({
+    contestId: 'AOJ-OUPC2024-day1',
+    expected: '（OUPC 2024 Day1）',
+  }),
 ];

--- a/src/test/lib/utils/test_cases/contest_type.ts
+++ b/src/test/lib/utils/test_cases/contest_type.ts
@@ -725,6 +725,11 @@ const aojUniversityContestData = [
   { name: 'AOJ, UAPC 2011 Summer', contestId: 'AOJ-UAPC2011-summer' },
   { name: 'AOJ, UAPC 2012 Day1', contestId: 'AOJ-UAPC2012-day1' },
   { name: 'AOJ, OUPC 2012 in RUPC 2012 Day2', contestId: 'AOJ-OUPC2012-in-RUPC2012-day2' },
+  { name: 'AOJ, OUPC 2020', contestId: 'AOJ-OUPC2020' },
+  { name: 'AOJ, OUPC 2024 Day1', contestId: 'AOJ-OUPC2024-day1' },
+  { name: 'AOJ, RUPC 2017 in ACPC 2017 Day1', contestId: 'AOJ-RUPC2017-in-ACPC2017-day1' },
+  { name: 'AOJ, HUPC 2019 in HUPC 2019 Day2', contestId: 'AOJ-HUPC2019-in-HUPC2019-day2' },
+  { name: 'AOJ, UAPC 2018 in RUPC 2018 Day2', contestId: 'AOJ-UAPC2018-in-RUPC2018-day2' },
 ];
 
 export const aojUniversity = aojUniversityContestData.map(({ name, contestId }) =>


### PR DESCRIPTION
Add tasks for UAPC2012, UAPC2018-in-RUPC2018, RUPC2017-in-ACPC2017, RUPC2025-in-ACPC2025-day1, HUPC2019, OUPC2020, and OUPC2024 with corresponding contest name and contest type test cases.

close #3863

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * AOJの公開タスクに、UAPC・RUPC・HUPC・OUPC関連の問題を9件追加しました。
  * 大学コンテストのタスク名やコンテスト種別を正しく表示できるようになりました。
* **テスト**
  * UAPC 2018、RUPC 2017、HUPC 2019、OUPC 2020、OUPC 2024のタスクおよび表示名を検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->