### PR TITLE
chore: switch packageImportMethod to auto and add audit ignorePrune

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,7 +11,7 @@ engineStrict: true
 resolutionMode: highest
 # necessary for a PNPM bug: https://github.com/pnpm/pnpm/issues/5152#issuecomment-1223449173
 strictPeerDependencies: false
-packageImportMethod: clone-or-copy
+packageImportMethod: auto
 
 # Security configuration: supply chain attack mitigation
 # Delay the adoption of newly released packages to allow detection of malicious code
@@ -32,6 +32,10 @@ minimumReleaseAgeExclude:
 
 # Prevent transitive dependencies from Git/Tarball sources (enhanced security)
 blockExoticSubdeps: true
+
+# Auto-remove GHSA entries from audit reports when they no longer appear
+audit:
+  ignorePrune: true
 
 # Security overrides: force transitive dependencies to patched versions
 # See: Issue #3761


### PR DESCRIPTION
pnpm v12 defaults to auto; clone-or-copy is no longer needed. Enable audit ignorePrune to auto-remove resolved GHSA entries.


Claude-Session: https://claude.ai/code/session_01LpBu3jvGWLNEeyWVL2PQZT

close #4015

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - 依存関係のインストール方式を自動選択に変更し、環境に応じた処理に対応しました。
  - 監査レポートから、該当しなくなったセキュリティ警告を自動的に削除するよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->